### PR TITLE
chore: Fix typo in InOperator

### DIFF
--- a/src/JsonPath/Expressions/InOperator.cs
+++ b/src/JsonPath/Expressions/InOperator.cs
@@ -31,6 +31,6 @@ internal class InOperator : IBinaryComparativeOperator
 
 	public override string ToString()
 	{
-		return "in";
+		return " in ";
 	}
 }

--- a/src/JsonPath/Expressions/InOperator.cs
+++ b/src/JsonPath/Expressions/InOperator.cs
@@ -31,6 +31,6 @@ internal class InOperator : IBinaryComparativeOperator
 
 	public override string ToString()
 	{
-		return "<";
+		return "in";
 	}
 }


### PR DESCRIPTION


### Description
fix typo, it should be `in`
