### PR TITLE
add evaluation option to disallow unknown keyword $ref navigation

### DIFF
--- a/src/JsonSchema/EvaluationOptions.cs
+++ b/src/JsonSchema/EvaluationOptions.cs
@@ -121,6 +121,12 @@ public class EvaluationOptions
 	/// </summary>
 	public CultureInfo? Culture { get; set; }
 
+	/// <summary>
+	/// Gets or sets whether `$ref` is permitted to navigate into unknown keywords
+	/// where subschemas aren't expected.  Default is true.
+	/// </summary>
+	public bool AllowReferencesIntoUnknownKeywords { get; set; } = true;
+
 	internal bool Changed { get; set; }
 
 	static EvaluationOptions()
@@ -158,7 +164,8 @@ public class EvaluationOptions
 			Culture = other.Culture,
 			_ignoredAnnotationTypes = other._ignoredAnnotationTypes == null
 				? null
-				: new HashSet<Type>(other._ignoredAnnotationTypes)
+				: new HashSet<Type>(other._ignoredAnnotationTypes),
+			AllowReferencesIntoUnknownKeywords = other.AllowReferencesIntoUnknownKeywords
 		};
 		options.SchemaRegistry.CopyFrom(other.SchemaRegistry);
 		return options;

--- a/src/JsonSchema/JsonSchema.cs
+++ b/src/JsonSchema/JsonSchema.cs
@@ -661,6 +661,9 @@ public class JsonSchema : IBaseDocument
 
 			if (newResolvable is UnrecognizedKeyword unrecognized)
 			{
+				if (!options.AllowReferencesIntoUnknownKeywords)
+					throw new InvalidOperationException($"Encountered reference into unknown keyword: {BaseUri}#{pointer}");
+
 #if NETSTANDARD2_0
 				var newPointer = pointer.GetLocal(i+1);
 #else

--- a/src/JsonSchema/JsonSchema.csproj
+++ b/src/JsonSchema/JsonSchema.csproj
@@ -17,8 +17,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>JsonSchema.Net</PackageId>
-    <Version>7.0.4</Version>
-    <FileVersion>7.0.4</FileVersion>
+    <Version>7.1.0</Version>
+    <FileVersion>7.1.0</FileVersion>
     <AssemblyVersion>7.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>JSON Schema built on the System.Text.Json namespace</Description>

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
@@ -4,6 +4,10 @@ title: JsonSchema.Net
 icon: fas fa-tag
 order: "09.01"
 ---
+# [7.1.0](https://github.com/gregsdennis/json-everything/pull/752) {#release-schema-7.1.0}
+
+Adds `EvaluationOptions.AllowReferencesIntoUnknownKeywords` to optionally disallow `$ref` navigation into unknown keywords.
+
 # [7.0.4](https://github.com/gregsdennis/json-everything/pull/746) {#release-schema-7.0.4}
 
 `minContains` and `maxContains` annotations were still being discovered by `contains` when validating as Draft 6/7 even though `minContains` and `maxContains` are Draft 2019-90+ keywords. 


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

Adds `EvaluationOptions.AllowReferencesIntoUnknownKeywords` to optionally disallow `$ref` navigation into unknown keywords.

### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
Relates to https://github.com/json-schema-org/json-schema-spec/issues/1528 / https://github.com/json-everything/json-everything/issues/753  <!-- Use if these changes relate to but do not resolve the issue -->

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
