### PR TITLE
JsonPointer.Net missing methods

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -39,6 +39,12 @@ jobs:
         with:
           name: Unit Test Results
           path: '**/*/test-results.trx'
+      - name: Upload Packages for Inspection
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: Packages
+          path: '**/*/*.nupkg'
 
   test-results:
     runs-on: ubuntu-latest

--- a/src/JsonPointer/JsonPointer.csproj
+++ b/src/JsonPointer/JsonPointer.csproj
@@ -16,8 +16,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>JsonPointer.Net</PackageId>
-    <Version>5.0.0</Version>
-    <FileVersion>5.0.0</FileVersion>
+    <Version>5.0.1</Version>
+    <FileVersion>5.0.1</FileVersion>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>JSON Pointer built on the System.Text.Json namespace</Description>

--- a/src/JsonSchema/AllOfKeyword.cs
+++ b/src/JsonSchema/AllOfKeyword.cs
@@ -69,7 +69,13 @@ public class AllOfKeyword : IJsonSchemaKeyword, ISchemaCollector
 	/// <returns>A constraint object.</returns>
 	public KeywordConstraint GetConstraint(SchemaConstraint schemaConstraint, ReadOnlySpan<KeywordConstraint> localConstraints, EvaluationContext context)
 	{
-		var subschemaConstraints = Schemas.Select((x, i) => x.GetConstraint(JsonPointer.Create(Name, i), schemaConstraint.BaseInstanceLocation, JsonPointer.Empty, context)).ToArray();
+		var subschemaConstraints = Schemas.Select((x, i) =>
+		{
+			context.PushEvaluationPath(i);
+			var constraint = x.GetConstraint(JsonPointer.Create(Name, i), schemaConstraint.BaseInstanceLocation, JsonPointer.Empty, context);
+			context.PopEvaluationPath();
+			return constraint;
+		}).ToArray();
 
 		return new KeywordConstraint(Name, Evaluator)
 		{

--- a/src/JsonSchema/AnyOfKeyword.cs
+++ b/src/JsonSchema/AnyOfKeyword.cs
@@ -69,7 +69,13 @@ public class AnyOfKeyword : IJsonSchemaKeyword, ISchemaCollector
 	/// <returns>A constraint object.</returns>
 	public KeywordConstraint GetConstraint(SchemaConstraint schemaConstraint, ReadOnlySpan<KeywordConstraint> localConstraints, EvaluationContext context)
 	{
-		var subschemaConstraints = Schemas.Select((x, i) => x.GetConstraint(JsonPointer.Create(Name, i), schemaConstraint.BaseInstanceLocation, JsonPointer.Empty, context)).ToArray();
+		var subschemaConstraints = Schemas.Select((x, i) =>
+		{
+			context.PushEvaluationPath(i);
+			var constraint = x.GetConstraint(JsonPointer.Create(Name, i), schemaConstraint.BaseInstanceLocation, JsonPointer.Empty, context);
+			context.PopEvaluationPath();
+			return constraint;
+		}).ToArray();
 
 		return new KeywordConstraint(Name, Evaluator)
 		{

--- a/src/JsonSchema/DependentSchemasKeyword.cs
+++ b/src/JsonSchema/DependentSchemasKeyword.cs
@@ -58,7 +58,9 @@ public class DependentSchemasKeyword : IJsonSchemaKeyword, IKeyedSchemaCollector
 	{
 		var subschemaConstraints = Schemas.Select(requirement =>
 		{
+			context.PushEvaluationPath(requirement.Key);
 			var subschemaConstraint = requirement.Value.GetConstraint(JsonPointer.Create(Name, requirement.Key), schemaConstraint.BaseInstanceLocation, JsonPointer.Empty, context);
+			context.PopEvaluationPath();
 			subschemaConstraint.InstanceLocator = evaluation =>
 			{
 				if (evaluation.LocalInstance is not JsonObject obj ||

--- a/src/JsonSchema/EvaluationContext.cs
+++ b/src/JsonSchema/EvaluationContext.cs
@@ -11,6 +11,9 @@ namespace Json.Schema;
 public class EvaluationContext
 {
 	private readonly Stack<SpecVersion> _evaluatingAs = new();
+#if DEBUG
+	private JsonPointer _evaluationPath = JsonPointer.Empty;
+#endif
 
 	/// <summary>
 	/// Gets the evaluation options.
@@ -66,5 +69,19 @@ public class EvaluationContext
 	{ 
 		_evaluatingAs.Pop();
 		EvaluatingAs = _evaluatingAs.Peek();
+	}
+
+	internal void PushEvaluationPath(PointerSegment segment)
+	{
+#if DEBUG
+		_evaluationPath = _evaluationPath.Combine(segment);
+#endif
+	}
+
+	internal void PopEvaluationPath()
+	{
+#if DEBUG
+		_evaluationPath = _evaluationPath.GetAncestor(1);
+#endif
 	}
 }

--- a/src/JsonSchema/JsonSchema.cs
+++ b/src/JsonSchema/JsonSchema.cs
@@ -429,7 +429,9 @@ public class JsonSchema : IBaseDocument
 				var refKeyword = (RefKeyword?) Keywords!.FirstOrDefault(x => x is RefKeyword);
 				if (refKeyword != null)
 				{
+					context.PushEvaluationPath(RefKeyword.Name);
 					var refConstraint = refKeyword.GetConstraint(constraint, [], context);  // indirect allocation
+					context.PopEvaluationPath();
 					constraint.Constraints = [refConstraint];  // allocation
 					return;
 				}
@@ -473,7 +475,9 @@ public class JsonSchema : IBaseDocument
 				KeywordConstraint? keywordConstraint;
 				if (ShouldProcessKeyword(keyword, context.Options.ProcessCustomKeywords, version, declaredKeywordTypes))
 				{
+					context.PushEvaluationPath(keyword.Keyword());
 					keywordConstraint = keyword.GetConstraint(constraint, localConstraints[..constraintCount], context);  // indirect allocation
+					context.PopEvaluationPath();
 					localConstraints[constraintCount] = keywordConstraint;
 					constraintCount++;
 

--- a/src/JsonSchema/PatternPropertiesKeyword.cs
+++ b/src/JsonSchema/PatternPropertiesKeyword.cs
@@ -78,7 +78,9 @@ public class PatternPropertiesKeyword : IJsonSchemaKeyword, IKeyedSchemaCollecto
 	{
 		var subschemaConstraints = Patterns.Select(pattern =>
 		{
+			context.PushEvaluationPath(pattern.Key.ToString());
 			var subschemaConstraint = pattern.Value.GetConstraint(_evaluationPointers[pattern.Key], schemaConstraint.BaseInstanceLocation, JsonPointer.Empty, context);
+			context.PopEvaluationPath();
 			subschemaConstraint.InstanceLocator = evaluation =>
 			{
 				if (evaluation.LocalInstance is not JsonObject obj) return [];

--- a/src/JsonSchema/PropertiesKeyword.cs
+++ b/src/JsonSchema/PropertiesKeyword.cs
@@ -63,7 +63,13 @@ public class PropertiesKeyword : IJsonSchemaKeyword, IKeyedSchemaCollector
 	/// <returns>A constraint object.</returns>
 	public KeywordConstraint GetConstraint(SchemaConstraint schemaConstraint, ReadOnlySpan<KeywordConstraint> localConstraints, EvaluationContext context)
 	{
-		var subschemaConstraints = Properties.Select(x => x.Value.GetConstraint(_evaluationPointers[x.Key], schemaConstraint.BaseInstanceLocation, _instancePointers[x.Key], context)).ToArray();
+		var subschemaConstraints = Properties.Select(x =>
+		{
+			context.PushEvaluationPath(x.Key);
+			var constraint = x.Value.GetConstraint(_evaluationPointers[x.Key], schemaConstraint.BaseInstanceLocation, _instancePointers[x.Key], context);
+			context.PopEvaluationPath();
+			return constraint;
+		}).ToArray();
 
 		return new KeywordConstraint(Name, Evaluator)
 		{

--- a/src/JsonSchema/PropertyDependenciesKeyword.cs
+++ b/src/JsonSchema/PropertyDependenciesKeyword.cs
@@ -57,9 +57,12 @@ public class PropertyDependenciesKeyword : IJsonSchemaKeyword, ICustomSchemaColl
 	{
 		var subschemaConstraints = Dependencies.SelectMany(property =>
 		{
+			context.PushEvaluationPath(property.Key);
 			var propertyConstraint = property.Value.Schemas.Select(requirement =>
 			{
+				context.PushEvaluationPath(requirement.Key);
 				var requirementConstraint = requirement.Value.GetConstraint(JsonPointer.Create(Name, property.Key), schemaConstraint.BaseInstanceLocation, JsonPointer.Empty, context);
+				context.PopEvaluationPath();
 				requirementConstraint.InstanceLocator = evaluation =>
 				{
 					if (evaluation.LocalInstance is not JsonObject obj ||
@@ -72,6 +75,7 @@ public class PropertyDependenciesKeyword : IJsonSchemaKeyword, ICustomSchemaColl
 
 				return requirementConstraint;
 			});
+			context.PopEvaluationPath();
 
 			return propertyConstraint;
 		}).ToArray();

--- a/tools/ApiDocsGenerator/release-notes/rn-json-pointer.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-pointer.md
@@ -4,6 +4,10 @@ title: JsonPointer.Net
 icon: fas fa-tag
 order: "09.10"
 ---
+# [5.0.1](https://github.com/gregsdennis/json-everything/pull/757) {#release-pointer-5.0.1}
+
+For some reason v5.0.0 was missing two methods: `.GetAncestor()` and `.GetLocal()`.  This is a republish to include those methods.
+
 # [5.0.0](https://github.com/gregsdennis/json-everything/pull/719) {#release-pointer-5.0.0}
 
 Complete overhaul of `JsonPointer` to reduce memory usage for consuming applications.


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

For some reason the DLL published to nuget seems to be missing `.GetAncestor()` and `.GetLocal()`.  Not sure why.

### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
Relates to https://github.com/gregsdennis/Graeae/pull/6

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
