### PR TITLE
JSON Pointer escapes not honored when pointer is constructed instead of parsed

### DIFF
--- a/src/JsonPatch/JsonPatch.csproj
+++ b/src/JsonPatch/JsonPatch.csproj
@@ -15,8 +15,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>JsonPatch.Net</PackageId>
-    <Version>3.1.0</Version>
-    <FileVersion>3.1.0</FileVersion>
+    <Version>3.1.1</Version>
+    <FileVersion>3.1.1</FileVersion>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>JSON Patch built on the System.Text.Json namespace</Description>

--- a/src/JsonPointer.Tests/JsonPointerParseTests.cs
+++ b/src/JsonPointer.Tests/JsonPointerParseTests.cs
@@ -136,6 +136,6 @@ public class JsonPointerParseTests
 		var pointer = JsonPointer.Create(segments.Select(x => (PointerSegment)x).ToArray());
 
 		var backToString = pointer.ToString();
-		Assert.That(backToString, Is.SameAs(pointerString));
+		Assert.That(backToString, Is.EqualTo(pointerString));
 	}
 }

--- a/src/JsonPointer.Tests/JsonPointerParseTests.cs
+++ b/src/JsonPointer.Tests/JsonPointerParseTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -11,7 +12,6 @@ public class JsonPointerParseTests
 	{
 		get
 		{
-			// Normal
 			yield return new TestCaseData("", new string[] { });
 			yield return new TestCaseData("/foo", new[] { "foo" });
 			yield return new TestCaseData("/foo/0", new[] { "foo", "0" });
@@ -30,7 +30,12 @@ public class JsonPointerParseTests
 			yield return new TestCaseData("/i%5Cj", new[] { "i%5Cj" });
 			yield return new TestCaseData("/k%22l", new[] { "k%22l" });
 			yield return new TestCaseData("/%20", new[] { "%20" });
-			// Url
+		}
+	}
+	public static IEnumerable UrlSpecificationExamples
+	{
+		get
+		{
 			yield return new TestCaseData("#", new string[] { });
 			yield return new TestCaseData("#/foo", new[] { "foo" });
 			yield return new TestCaseData("#/foo/0", new[] { "foo", "0" });
@@ -61,6 +66,7 @@ public class JsonPointerParseTests
 	}
 
 	[TestCaseSource(nameof(SpecificationExamples))]
+	[TestCaseSource(nameof(UrlSpecificationExamples))]
 	public void Parse(string pointerString, string[] segments)
 	{
 		var pointer = JsonPointer.Parse(pointerString);
@@ -122,5 +128,14 @@ public class JsonPointerParseTests
 		var actual = pointer!.ToString();
 
 		Assert.That(actual, Is.EqualTo(expected));
+	}
+
+	[TestCaseSource(nameof(SpecificationExamples))]
+	public void CreateThenToString(string pointerString, string[] segments)
+	{
+		var pointer = JsonPointer.Create(segments.Select(x => (PointerSegment)x).ToArray());
+
+		var backToString = pointer.ToString();
+		Assert.That(backToString, Is.SameAs(pointerString));
 	}
 }

--- a/src/JsonPointer/JsonPointer.csproj
+++ b/src/JsonPointer/JsonPointer.csproj
@@ -16,8 +16,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>JsonPointer.Net</PackageId>
-    <Version>5.0.1</Version>
-    <FileVersion>5.0.1</FileVersion>
+    <Version>5.0.2</Version>
+    <FileVersion>5.0.2</FileVersion>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>JSON Pointer built on the System.Text.Json namespace</Description>

--- a/src/JsonPointer/SpanExtensions.cs
+++ b/src/JsonPointer/SpanExtensions.cs
@@ -1,29 +1,9 @@
 ﻿using System;
-using System.Buffers;
 
 namespace Json.Pointer;
 
 internal static class SpanExtensions
 {
-	internal static string Decode(this string value)
-	{
-		using var memory = MemoryPool<char>.Shared.Rent();
-		var span = memory.Memory.Span;
-		var sourceIndex = 0;
-		var spanIndex = 0;
-		var sourceSpan = value.AsSpan();
-		while (sourceIndex < value.Length)
-		{
-			span[spanIndex] = Decode(sourceSpan, ref sourceIndex);
-			spanIndex++;
-			sourceIndex++;
-		}
-
-		return spanIndex == sourceIndex
-			? value
-			: span[..spanIndex].ToString();
-	}
-
 	internal static char Decode(this ReadOnlySpan<char> value, ref int index)
 	{
 		var ch = value[index];
@@ -64,33 +44,30 @@ internal static class SpanExtensions
 		}
 	}
 
-	internal static ReadOnlySpan<char> Encode(this ReadOnlySpan<char> key)
+	internal static int Encode(this ReadOnlySpan<char> key, Span<char> encoded)
 	{
-		using var owner = MemoryPool<char>.Shared.Rent(key.Length * 2);
-		var span = owner.Memory.Span;
-
 		var length = 0;
 		foreach (var ch in key)
 		{
 			switch (ch)
 			{
 				case '~':
-					span[length] = '~';
-					span[length + 1] = '0';
+					encoded[length] = '~';
+					encoded[length + 1] = '0';
 					length += 2;
 					break;
 				case '/':
-					span[length] = '~';
-					span[length + 1] = '1';
+					encoded[length] = '~';
+					encoded[length + 1] = '1';
 					length += 2;
 					break;
 				default:
-					span[length] = ch;
+					encoded[length] = ch;
 					length++;
 					break;
 			}
 		}
 
-		return span[..length];
+		return length;
 	}
 }

--- a/src/JsonSchema/JsonSchema.csproj
+++ b/src/JsonSchema/JsonSchema.csproj
@@ -17,8 +17,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>JsonSchema.Net</PackageId>
-    <Version>7.1.1</Version>
-    <FileVersion>7.1.1</FileVersion>
+    <Version>7.1.2</Version>
+    <FileVersion>7.1.2</FileVersion>
     <AssemblyVersion>7.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>JSON Schema built on the System.Text.Json namespace</Description>

--- a/tools/ApiDocsGenerator/release-notes/rn-json-patch.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-patch.md
@@ -4,6 +4,10 @@ title: JsonPatch.Net
 icon: fas fa-tag
 order: "09.09"
 ---
+# [3.1.1](https://github.com/gregsdennis/json-everything/pull/759) {#release-patch-3.1.1}
+
+Update to use _JsonPointer.Net_ v5.0.2.
+
 # [3.1.0](https://github.com/gregsdennis/json-everything/pull/719) {#release-patch-3.1.0}
 
 Updated to use _JsonPointer.Net_ v5.0.0, which contains breaking changes ([release notes](/rn-json-pointer/#release-pointer-5.0.0)).

--- a/tools/ApiDocsGenerator/release-notes/rn-json-pointer.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-pointer.md
@@ -4,6 +4,10 @@ title: JsonPointer.Net
 icon: fas fa-tag
 order: "09.10"
 ---
+# [5.0.2](https://github.com/gregsdennis/json-everything/pull/759) {#release-pointer-5.0.2}
+
+Fixed a problem with `.ToString()` where pointers constructed using `JsonPointer.Create()` would not properly escape segments.
+
 # [5.0.1](https://github.com/gregsdennis/json-everything/pull/757) {#release-pointer-5.0.1}
 
 For some reason v5.0.0 was missing two methods: `.GetAncestor()` and `.GetLocal()`.  This is a republish to include those methods.

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
@@ -4,6 +4,10 @@ title: JsonSchema.Net
 icon: fas fa-tag
 order: "09.01"
 ---
+# [7.1.2](https://github.com/gregsdennis/json-everything/pull/759) {#release-schema-7.1.2}
+
+Update to use _JsonPointer.Net_ v5.0.2.
+
 # [7.1.1](https://github.com/gregsdennis/json-everything/pull/755) {#release-schema-7.1.1}
 
 Added a backdoor to allow Graeae to support draft 4 schemas.


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

When building a JSON Pointer using `JsonPointer.Create()`, `.ToString()` doesn't escape segments.

### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
Resolves #754

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
