### PR TITLE
Descriptions for deeply nested types not added to schema generation

### DIFF
--- a/src/JsonSchema.Generation.Tests/ClientTests.cs
+++ b/src/JsonSchema.Generation.Tests/ClientTests.cs
@@ -369,31 +369,31 @@ public class ClientTests
 		public class NestedType
 		{
 			/// <summary>
-			/// The names
+			/// Names property on NestedType
 			/// </summary>
 			public List<string> Names { get; set; } = [];
 
 			/// <summary>
-			/// The descriptions
+			/// Descriptions property on NestedType
 			/// </summary>
 			public List<string> Descriptions { get; set; } = [];
 
 			public class NestedNestedType
 			{
 				/// <summary>
-				/// The nested names
+				/// NestedNames property on NestedNestedType (double-nested)
 				/// </summary>
 				public List<string> NestedNames { get; set; } = [];
 			}
 
 			/// <summary>
-			/// Next level stuff
+			/// NestedNested property on NestedType
 			/// </summary>
 			public NestedNestedType NestedNested = new();
 		}
 
 		/// <summary>
-		/// The nested type
+		/// Nested property on Issue767_PropertyLevelComments
 		/// </summary>
 		public NestedType? Nested = new();
 	}
@@ -407,15 +407,46 @@ public class ClientTests
 			{
 			  "type": "object",
 			  "properties": {
-			    "Apr": {
-			      "type": ["number", "null"],
-			      "multipleOf": 0.1
+			    "Nested": {
+			      "type": "object",
+			      "properties": {
+			        "NestedNested": {
+			          "type": "object",
+			          "properties": {
+			            "NestedNames": {
+			              "type": "array",
+			              "items": {
+			                "type": "string"
+			              },
+			              "description": "NestedNames property on NestedNestedType (double-nested)"
+			            }
+			          },
+			          "description": "NestedNested property on NestedType"
+			        },
+			        "Names": {
+			          "type": "array",
+			          "items": {
+			            "type": "string"
+			          },
+			          "description": "Names property on NestedType"
+			        },
+			        "Descriptions": {
+			          "type": "array",
+			          "items": {
+			            "type": "string"
+			          },
+			          "description": "Descriptions property on NestedType"
+			        }
+			      },
+			      "description": "Nested property on Issue767_PropertyLevelComments"
 			    }
 			  }
 			}
 			""");
 
-		JsonSchema schema = new JsonSchemaBuilder().FromType<Issue767_PropertyLevelComments>();
+		var options = new SchemaGeneratorConfiguration { Optimize = false };
+		options.RegisterXmlCommentFile<Issue767_PropertyLevelComments>("JsonSchema.Net.Generation.Tests.xml");
+		JsonSchema schema = new JsonSchemaBuilder().FromType<Issue767_PropertyLevelComments>(options);
 		var schemaJson = JsonSerializer.SerializeToNode(schema, TestSerializerContext.Default.JsonSchema);
 		Console.WriteLine(schemaJson);
 

--- a/src/JsonSchema.Generation.Tests/ClientTests.cs
+++ b/src/JsonSchema.Generation.Tests/ClientTests.cs
@@ -363,4 +363,62 @@ public class ClientTests
 
 		Assert.That(schemaJson.IsEquivalentTo(expected), Is.True);
 	}
+
+	public class Issue767_PropertyLevelComments
+	{
+		public class NestedType
+		{
+			/// <summary>
+			/// The names
+			/// </summary>
+			public List<string> Names { get; set; } = [];
+
+			/// <summary>
+			/// The descriptions
+			/// </summary>
+			public List<string> Descriptions { get; set; } = [];
+
+			public class NestedNestedType
+			{
+				/// <summary>
+				/// The nested names
+				/// </summary>
+				public List<string> NestedNames { get; set; } = [];
+			}
+
+			/// <summary>
+			/// Next level stuff
+			/// </summary>
+			public NestedNestedType NestedNested = new();
+		}
+
+		/// <summary>
+		/// The nested type
+		/// </summary>
+		public NestedType? Nested = new();
+	}
+
+
+	[Test]
+	public void Issue767_PropertyDescriptionFromXmlComments()
+	{
+		var expected = JsonNode.Parse(
+			"""
+			{
+			  "type": "object",
+			  "properties": {
+			    "Apr": {
+			      "type": ["number", "null"],
+			      "multipleOf": 0.1
+			    }
+			  }
+			}
+			""");
+
+		JsonSchema schema = new JsonSchemaBuilder().FromType<Issue767_PropertyLevelComments>();
+		var schemaJson = JsonSerializer.SerializeToNode(schema, TestSerializerContext.Default.JsonSchema);
+		Console.WriteLine(schemaJson);
+
+		Assert.That(schemaJson.IsEquivalentTo(expected), Is.True);
+	}
 }

--- a/src/JsonSchema.Generation.Tests/ClientTests.cs
+++ b/src/JsonSchema.Generation.Tests/ClientTests.cs
@@ -411,40 +411,57 @@ public class ClientTests
 			      "type": "object",
 			      "properties": {
 			        "NestedNested": {
-			          "type": "object",
-			          "properties": {
-			            "NestedNames": {
-			              "type": "array",
-			              "items": {
-			                "type": "string"
-			              },
-			              "description": "NestedNames property on NestedNestedType (double-nested)"
-			            }
-			          },
-			          "description": "NestedNested property on NestedType"
+			          "$ref": "#/$defs/nestedNestedTypeInNestedTypeInIssue767PropertyLevelCommentsInClientTests"
 			        },
 			        "Names": {
-			          "type": "array",
-			          "items": {
-			            "type": "string"
-			          },
-			          "description": "Names property on NestedType"
+			          "$ref": "#/$defs/listOfString1"
 			        },
 			        "Descriptions": {
-			          "type": "array",
-			          "items": {
-			            "type": "string"
-			          },
-			          "description": "Descriptions property on NestedType"
+			          "$ref": "#/$defs/listOfString2"
 			        }
 			      },
 			      "description": "Nested property on Issue767_PropertyLevelComments"
+			    }
+			  },
+			  "$defs": {
+			    "nestedNestedTypeInNestedTypeInIssue767PropertyLevelCommentsInClientTests": {
+			      "type": "object",
+			      "properties": {
+			        "NestedNames": {
+			          "$ref": "#/$defs/listOfString"
+			        }
+			      },
+			      "description": "NestedNested property on NestedType"
+			    },
+			    "listOfString": {
+			      "type": "array",
+			      "items": {
+			        "type": "string",
+			        "description": "NestedNames property on NestedNestedType (double-nested)"
+			      },
+			      "description": "NestedNames property on NestedNestedType (double-nested)"
+			    },
+			    "listOfString1": {
+			      "type": "array",
+			      "items": {
+			        "type": "string",
+			        "description": "Names property on NestedType"
+			      },
+			      "description": "Names property on NestedType"
+			    },
+			    "listOfString2": {
+			      "type": "array",
+			      "items": {
+			        "type": "string",
+			        "description": "Descriptions property on NestedType"
+			      },
+			      "description": "Descriptions property on NestedType"
 			    }
 			  }
 			}
 			""");
 
-		var options = new SchemaGeneratorConfiguration { Optimize = false };
+		var options = new SchemaGeneratorConfiguration { Optimize = true };
 		options.RegisterXmlCommentFile<Issue767_PropertyLevelComments>("JsonSchema.Net.Generation.Tests.xml");
 		JsonSchema schema = new JsonSchemaBuilder().FromType<Issue767_PropertyLevelComments>(options);
 		var schemaJson = JsonSerializer.SerializeToNode(schema, TestSerializerContext.Default.JsonSchema);

--- a/src/JsonSchema.Generation/JsonSchema.Generation.csproj
+++ b/src/JsonSchema.Generation/JsonSchema.Generation.csproj
@@ -15,8 +15,8 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>4.3.0.2</Version>
-    <FileVersion>4.3.0.2</FileVersion>
+    <Version>4.4.0</Version>
+    <FileVersion>4.4.0</FileVersion>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>Extends JsonSchema.Net to provide schema generation functionality</Description>

--- a/src/JsonSchema.Generation/XmlComments/XmlDocId.cs
+++ b/src/JsonSchema.Generation/XmlComments/XmlDocId.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Json.Schema.Generation.XmlComments;
@@ -176,7 +177,7 @@ internal static class XmlDocId
 
 		var args = type.GetGenericArguments();
 		string fullTypeName;
-		var typeNamespace = type.Namespace == null ? "" : $"{type.Namespace}.";
+		var typeNamespace = type.Namespace == null ? "" : $"{type.Namespace}";
 		var outString = isOut ? "@" : "";
 
 		if (type.MemberType == MemberTypes.TypeInfo &&
@@ -186,15 +187,22 @@ internal static class XmlDocId
 			var paramString = string.Join(",",
 				args.Select(o => GetTypeXmlId(o, false, isMethodParameter, genericClassParams)));
 			var typeName = Regex.Replace(type.Name, "`[0-9]+", "{" + paramString + "}");
-			fullTypeName = $"{typeNamespace}{typeName}{outString}";
+			fullTypeName = $"{typeNamespace}.{typeName}{outString}";
 		}
 		else if (type.IsNested)
 		{
-			fullTypeName = $"{typeNamespace}{type.DeclaringType!.Name}.{type.Name}{outString}";
+			var current = type;
+			var nestedStructure = string.Empty;
+			while (current!.IsNested)
+			{
+				nestedStructure = $".{current.DeclaringType!.Name}{nestedStructure}";
+				current = current.DeclaringType;
+			}
+			fullTypeName = $"{typeNamespace}{nestedStructure}.{type.Name}{outString}";
 		}
 		else
 		{
-			fullTypeName = $"{typeNamespace}{type.Name}{outString}";
+			fullTypeName = $"{typeNamespace}.{type.Name}{outString}";
 		}
 
 		fullTypeName = fullTypeName.Replace("&", "");

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema-generation.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema-generation.md
@@ -8,7 +8,7 @@ order: "09.05"
 
 Updated to use _JsonSchema.Net_ v7.0.0, which contains breaking changes ([release notes](/rn-json-schema/#release-schema-7.0.0)).
 
-[#767](https://github.com/gregsdennis/json-everything/issues/767) - Missing `description` keyword from XML comments on multi-nested types.
+[#767](https://github.com/gregsdennis/json-everything/issues/767) - Missing `description` keyword from XML comments on multi-nested types.  Thanks to [@parnic-sks](https://github.com/parnic-sks) for reporting this.
 
 # [4.3.0.x](https://github.com/gregsdennis/json-everything/pull/712) {#release-schemagen-4.3.0.x}
 

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema-generation.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema-generation.md
@@ -4,9 +4,11 @@ title: JsonSchema.Net.Generation
 icon: fas fa-tag
 order: "09.05"
 ---
-# [4.4.0](https://github.com/gregsdennis/json-everything/pull/719) {#release-schemagen-4.4.0}
+# [4.4.0](https://github.com/gregsdennis/json-everything/pull/770) {#release-schemagen-4.4.0}
 
 Updated to use _JsonSchema.Net_ v7.0.0, which contains breaking changes ([release notes](/rn-json-schema/#release-schema-7.0.0)).
+
+[#767](https://github.com/gregsdennis/json-everything/issues/767) - Missing `description` keyword from XML comments on multi-nested types.
 
 # [4.3.0.x](https://github.com/gregsdennis/json-everything/pull/712) {#release-schemagen-4.3.0.x}
 


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

The `[Description]` attribute and the resulting `description` keyword can be improved.  There are some complications around optimizations and the attribute being able to appear on both the property and the type.

Currently exploring options.

### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
Resolves #767
Relates to #769

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
