### PR TITLE
Improve performance of regex usage in JsonSchema

### DIFF
--- a/src/JsonSchema.DataGeneration/Generators/StringGenerator.cs
+++ b/src/JsonSchema.DataGeneration/Generators/StringGenerator.cs
@@ -66,7 +66,7 @@ internal class StringGenerator : IDataGenerator
 			//if (context.AntiPatterns != null)
 			//	overallRegex += HelperExtensions.Forbid(context.AntiPatterns.Select(x => x.ToString()));
 			if (context.Pattern != null)
-				overallRegex = context.Pattern.ToString();
+				overallRegex = context.Pattern;
 
 			Console.WriteLine(overallRegex);
 

--- a/src/JsonSchema.DataGeneration/Requirements/StringRequirementsGatherer.cs
+++ b/src/JsonSchema.DataGeneration/Requirements/StringRequirementsGatherer.cs
@@ -32,7 +32,7 @@ internal class StringRequirementsGatherer : IRequirementsGatherer
 			supportsStrings = true;
 		}
 
-		var pattern = schema.Keywords?.OfType<PatternKeyword>().FirstOrDefault()?.Value;
+		var pattern = schema.Keywords?.OfType<PatternKeyword>().FirstOrDefault()?.Pattern;
 		if (pattern != null)
 		{
 			//context.Patterns ??= new List<Regex>();

--- a/src/JsonSchema.DataGeneration/RequirementsContext.cs
+++ b/src/JsonSchema.DataGeneration/RequirementsContext.cs
@@ -31,7 +31,7 @@ internal class RequirementsContext
 	// https://www.ocpsoft.org/tutorials/regular-expressions/and-in-regex/
 	//public List<Regex>? Patterns { get; set; }
 	//public List<Regex>? AntiPatterns { get; set; }
-	public Regex? Pattern { get; set; }
+	public string? Pattern { get; set; }
 	public string? Format { get; set; }
 
 	public List<RequirementsContext>? SequentialItems { get; set; }

--- a/src/JsonSchema/AnchorKeyword.cs
+++ b/src/JsonSchema/AnchorKeyword.cs
@@ -18,14 +18,27 @@ namespace Json.Schema;
 [Vocabulary(Vocabularies.Core202012Id)]
 [Vocabulary(Vocabularies.CoreNextId)]
 [JsonConverter(typeof(AnchorKeywordJsonConverter))]
-public class AnchorKeyword : IJsonSchemaKeyword
+public partial class AnchorKeyword : IJsonSchemaKeyword
 {
 	/// <summary>
 	/// The JSON name of the keyword.
 	/// </summary>
 	public const string Name = "$anchor";
-	internal static readonly Regex AnchorPattern201909 = new("^[A-Za-z][-A-Za-z0-9.:_]*$");
-	internal static readonly Regex AnchorPattern202012 = new("^[A-Za-z_][-A-Za-z0-9._]*$");
+
+
+#if NET7_0_OR_GREATER
+	[GeneratedRegex("^[A-Za-z][-A-Za-z0-9.:_]*$", RegexOptions.Compiled)]
+	private static partial Regex GetAnchorPattern201909Regex();
+	internal static Regex AnchorPattern201909 => GetAnchorPattern201909Regex();
+
+	[GeneratedRegex("^[A-Za-z_][-A-Za-z0-9._]*$", RegexOptions.Compiled)]
+	private static partial Regex GetAnchorPattern202012Regex();
+	internal static Regex AnchorPattern202012 => GetAnchorPattern202012Regex();
+
+#else
+	internal static readonly Regex AnchorPattern201909 = new("^[A-Za-z][-A-Za-z0-9.:_]*$", RegexOptions.Compiled);
+	internal static readonly Regex AnchorPattern202012 = new("^[A-Za-z_][-A-Za-z0-9._]*$", RegexOptions.Compiled);
+#endif
 
 	/// <summary>
 	/// The value of the anchor.

--- a/src/JsonSchema/Formats.cs
+++ b/src/JsonSchema/Formats.cs
@@ -25,9 +25,9 @@ public static class Formats
 		"HH':'mm':'ssK",
 		"HH':'mm':'ss"
 	};
-	
+
 	//from built from https://regex101.com/r/qH0sU7/1, edited to support all date+time examples in https://ijmacd.github.io/rfc3339-iso8601/
-	private static readonly Regex _dateTimeRegex = new Regex(@"^((?:(\d{4}-\d{2}-\d{2})([Tt_]| )(\d{2}:\d{2}:\d{2}(?:\.\d+)?))([Zz]|[\+-]\d{2}:\d{2}))$");
+	private static readonly Regex _dateTimeRegex = new Regex(@"^((?:(\d{4}-\d{2}-\d{2})([Tt_]| )(\d{2}:\d{2}:\d{2}(?:\.\d+)?))([Zz]|[\+-]\d{2}:\d{2}))$", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
 
 	/// <summary>
 	/// Defines the `date` format.

--- a/src/JsonSchema/Formats.cs
+++ b/src/JsonSchema/Formats.cs
@@ -59,7 +59,6 @@ public static partial class Formats
 	[GeneratedRegex("^[a-zA-Z][-.a-zA-Z0-9]{0,22}[a-zA-Z0-9]$", RegexOptions.Compiled, 250)]
 	private static partial Regex HostnameRegex();
 #else
-//from built from https://regex101.com/r/qH0sU7/1, edited to support all date+time examples in https://ijmacd.github.io/rfc3339-iso8601/
 	private static readonly Regex _hostnameRegex = new Regex("^[a-zA-Z][-.a-zA-Z0-9]{0,22}[a-zA-Z0-9]$", RegexOptions.Compiled, TimeSpan.FromMilliseconds(250));
 
 	private static Regex HostnameRegex()=>_hostnameRegex;
@@ -233,7 +232,6 @@ public static partial class Formats
 	[GeneratedRegex("^(?(\")(\".+?(?<!\\\\)\"@)|(([0-9a-z]((\\.(?!\\.))|[-!#\\$%&'\\*\\+/=\\?\\^`\\{\\}\\|~\\w])*)(?<=[0-9a-z])@))(?(\\[)(\\[(\\d{1,3}\\.){3}\\d{1,3}\\])|(([0-9a-z][-0-9a-z]*[0-9a-z]*\\.)+[a-z0-9][\\-a-z0-9]{0,22}[a-z0-9]))$", RegexOptions.Compiled| RegexOptions.IgnoreCase, 250)]
 	private static partial Regex EmailFormatRegex();
 #else
-//from built from https://regex101.com/r/qH0sU7/1, edited to support all date+time examples in https://ijmacd.github.io/rfc3339-iso8601/
 	private static readonly Regex _normalizeDomainRegex = new Regex(@"(@)(.+)$", RegexOptions.Compiled, TimeSpan.FromMilliseconds(250));
 
 	private static Regex NormalizeDomainRegex()=>_normalizeDomainRegex;

--- a/src/JsonSchema/JsonSchemaBuilderExtensions.cs
+++ b/src/JsonSchema/JsonSchemaBuilderExtensions.cs
@@ -682,7 +682,7 @@ public static class JsonSchemaBuilderExtensions
 	/// Add a `pattern` keyword.
 	/// </summary>
 	/// <param name="builder">The builder.</param>
-	/// <param name="pattern">The pattern to match.</param>
+	/// <param name="pattern">The Regex instance to match.</param>
 	/// <returns>The builder.</returns>
 	public static JsonSchemaBuilder Pattern(this JsonSchemaBuilder builder, Regex pattern)
 	{
@@ -698,7 +698,7 @@ public static class JsonSchemaBuilderExtensions
 	/// <returns>The builder.</returns>
 	public static JsonSchemaBuilder Pattern(this JsonSchemaBuilder builder, [StringSyntax(StringSyntaxAttribute.Regex)] string pattern)
 	{
-		builder.Add(new PatternKeyword(new Regex(pattern, RegexOptions.ECMAScript | RegexOptions.Compiled)));
+		builder.Add(new PatternKeyword(pattern));
 		return builder;
 	}
 
@@ -722,7 +722,7 @@ public static class JsonSchemaBuilderExtensions
 	/// <returns>The builder.</returns>
 	public static JsonSchemaBuilder PatternProperties(this JsonSchemaBuilder builder, params (Regex pattern, JsonSchema schema)[] props)
 	{
-		builder.Add(new PatternPropertiesKeyword(props.ToDictionary(x => x.pattern, x => x.schema)));
+		builder.Add(new PatternPropertiesKeyword(props));
 		return builder;
 	}
 
@@ -734,7 +734,7 @@ public static class JsonSchemaBuilderExtensions
 	/// <returns>The builder.</returns>
 	public static JsonSchemaBuilder PatternProperties(this JsonSchemaBuilder builder, IReadOnlyDictionary<string, JsonSchema> props)
 	{
-		builder.Add(new PatternPropertiesKeyword(props.ToDictionary(x => new Regex(x.Key), x => x.Value)));
+		builder.Add(new PatternPropertiesKeyword(props));
 		return builder;
 	}
 
@@ -746,7 +746,7 @@ public static class JsonSchemaBuilderExtensions
 	/// <returns>The builder.</returns>
 	public static JsonSchemaBuilder PatternProperties(this JsonSchemaBuilder builder, params (string pattern, JsonSchema schema)[] props)
 	{
-		builder.Add(new PatternPropertiesKeyword(props.ToDictionary(x => new Regex(x.pattern), x => x.schema)));
+		builder.Add(new PatternPropertiesKeyword(props));
 		return builder;
 	}
 

--- a/src/JsonSchema/JsonSchemaExtensions.KeywordAccess.cs
+++ b/src/JsonSchema/JsonSchemaExtensions.KeywordAccess.cs
@@ -365,18 +365,19 @@ public static partial class JsonSchemaExtensions
 	/// <summary>
 	/// Gets the value of `pattern` if the keyword exists.
 	/// </summary>
-	public static Regex? GetPattern(this JsonSchema schema)
+	public static string GetPattern(this JsonSchema schema)
 	{
-		return schema.TryGetKeyword<PatternKeyword>(PatternKeyword.Name, out var k) ? k.Value : null;
+		return schema.TryGetKeyword<PatternKeyword>(PatternKeyword.Name, out var k) ? k.Pattern : null;
 	}
 
 	/// <summary>
 	/// Gets the schemas in `patternProperties` if the keyword exists.
 	/// </summary>
-	public static IReadOnlyDictionary<Regex, JsonSchema>? GetPatternProperties(this JsonSchema schema)
+	public static IReadOnlyDictionary<string, JsonSchema>? GetPatternProperties(this JsonSchema schema)
 	{
 		return schema.TryGetKeyword<PatternPropertiesKeyword>(PatternPropertiesKeyword.Name, out var k) ? k.Patterns : null;
 	}
+
 
 	/// <summary>
 	/// Gets the schemas in `prefixItems` if the keyword exists.

--- a/src/JsonSchema/JsonSchemaExtensions.KeywordAccess.cs
+++ b/src/JsonSchema/JsonSchemaExtensions.KeywordAccess.cs
@@ -363,9 +363,18 @@ public static partial class JsonSchemaExtensions
 	}
 
 	/// <summary>
+	/// Gets the Regex of `pattern` if the keyword exists.
+	/// </summary>
+	[Obsolete($"Please use '{nameof(GetPatternValue)}' instead.")]
+	public static Regex GetPattern(this JsonSchema schema)
+	{
+		return schema.TryGetKeyword<PatternKeyword>(PatternKeyword.Name, out var k) ? k.Value : null;
+	}
+
+	/// <summary>
 	/// Gets the value of `pattern` if the keyword exists.
 	/// </summary>
-	public static string GetPattern(this JsonSchema schema)
+	public static string GetPatternValue(this JsonSchema schema)
 	{
 		return schema.TryGetKeyword<PatternKeyword>(PatternKeyword.Name, out var k) ? k.Pattern : null;
 	}
@@ -373,9 +382,18 @@ public static partial class JsonSchemaExtensions
 	/// <summary>
 	/// Gets the schemas in `patternProperties` if the keyword exists.
 	/// </summary>
-	public static IReadOnlyDictionary<string, JsonSchema>? GetPatternProperties(this JsonSchema schema)
+	[Obsolete($"Please use '{nameof(GetPatternPropertiesValues)}' instead.")]
+	public static IReadOnlyDictionary<Regex, JsonSchema>? GetPatternProperties(this JsonSchema schema)
 	{
 		return schema.TryGetKeyword<PatternPropertiesKeyword>(PatternPropertiesKeyword.Name, out var k) ? k.Patterns : null;
+	}
+
+	/// <summary>
+	/// Gets the schemas in `patternProperties` if the keyword exists.
+	/// </summary>
+	public static IReadOnlyDictionary<string, JsonSchema>? GetPatternPropertiesValues(this JsonSchema schema)
+	{
+		return schema.TryGetKeyword<PatternPropertiesKeyword>(PatternPropertiesKeyword.Name, out var k) ? k.PatternValues : null;
 	}
 
 

--- a/src/JsonSchema/PatternKeyword.cs
+++ b/src/JsonSchema/PatternKeyword.cs
@@ -35,6 +35,12 @@ public class PatternKeyword : IJsonSchemaKeyword
 
 	public string Pattern => _regexOrPattern;
 
+	/// <summary>
+	/// Returns the Regex Value of the keyword
+	/// </summary>
+	[Obsolete($"Please use the '{nameof(Pattern)}' property instead.")]
+	public Regex Value => _regexOrPattern.ToRegex();
+
 
 	/// <summary>
 	/// Creates a new <see cref="PatternKeyword"/> based on a regular expression pattern.

--- a/src/JsonSchema/PatternPropertiesKeyword.cs
+++ b/src/JsonSchema/PatternPropertiesKeyword.cs
@@ -25,43 +25,56 @@ namespace Json.Schema;
 [JsonConverter(typeof(PatternPropertiesKeywordJsonConverter))]
 public class PatternPropertiesKeyword : IJsonSchemaKeyword, IKeyedSchemaCollector
 {
-	private readonly Dictionary<Regex, JsonPointer> _evaluationPointers;
-	private readonly Dictionary<string, JsonSchema> _schemas;
+	private readonly IReadOnlyDictionary<string, (RegexOrPattern Regex, JsonPointer Pointer, JsonSchema Schema)> _patternsLookup;
 
 	/// <summary>
 	/// The JSON name of the keyword.
 	/// </summary>
 	public const string Name = "patternProperties";
 
-	/// <summary>
-	/// The pattern-keyed schemas.
-	/// </summary>
-	public IReadOnlyDictionary<Regex, JsonSchema> Patterns { get; }
-	/// <summary>
-	/// If any pattern is invalid or unsupported by <see cref="Regex"/>, it will appear here.
-	/// </summary>
-	/// <remarks>
-	/// All validations will fail if this is populated.
-	/// </remarks>
-	public IReadOnlyList<string>? InvalidPatterns { get; }
+	private Dictionary<string, JsonSchema>? _patterns;
 
-	IReadOnlyDictionary<string, JsonSchema> IKeyedSchemaCollector.Schemas => _schemas;
+	/// <summary>
+	/// The patterns of this PatternPropertiesKeyword
+	/// </summary>
+	public IReadOnlyDictionary<string, JsonSchema> Patterns => _patterns ??= _patternsLookup.ToDictionary(x => x.Key, x => x.Value.Schema);
+
+	IReadOnlyDictionary<string, JsonSchema> IKeyedSchemaCollector.Schemas => Patterns;
 
 	/// <summary>
 	/// Creates a new <see cref="PatternPropertiesKeyword"/>.
 	/// </summary>
 	/// <param name="values">The pattern-keyed schemas.</param>
-	public PatternPropertiesKeyword(IReadOnlyDictionary<Regex, JsonSchema> values)
+	public PatternPropertiesKeyword(IEnumerable<KeyValuePair<string, JsonSchema>> values)
 	{
-		Patterns = values ?? throw new ArgumentNullException(nameof(values));
-
-		_evaluationPointers = values.ToDictionary(x => x.Key, x => JsonPointer.Create(Name, x.Key.ToString()));
-		_schemas = Patterns.ToDictionary(x => x.Key.ToString(), x => x.Value);
+		_patternsLookup = values.ToDictionary(x => x.Key, x => (new RegexOrPattern(x.Key), JsonPointer.Create(Name, x.Key), x.Value), StringComparer.Ordinal);
 	}
-	internal PatternPropertiesKeyword(IReadOnlyDictionary<Regex, JsonSchema> values, IReadOnlyList<string> invalidPatterns)
-		: this(values)
+
+	/// <summary>
+	/// Creates a new <see cref="PatternPropertiesKeyword"/>.
+	/// </summary>
+	/// <param name="values">The pattern-keyed schemas.</param>
+	public PatternPropertiesKeyword(IEnumerable<(string Pattern, JsonSchema Schema)> values)
 	{
-		InvalidPatterns = invalidPatterns;
+		_patternsLookup = values.ToDictionary(x => x.Pattern, x => (new RegexOrPattern(x.Pattern), JsonPointer.Create(Name, x.Pattern), x.Schema), StringComparer.Ordinal);
+	}
+
+	/// <summary>
+	/// Creates a new <see cref="PatternPropertiesKeyword"/>.
+	/// </summary>
+	/// <param name="values">The pattern-keyed schemas.</param>
+	public PatternPropertiesKeyword(IEnumerable<(Regex Pattern, JsonSchema Schema)> values)
+	{
+		_patternsLookup = values.ToDictionary(x => x.Pattern.ToString(), x => (new RegexOrPattern(x.Pattern), JsonPointer.Create(Name, x.Pattern.ToString()), x.Schema), StringComparer.Ordinal);
+	}
+
+	/// <summary>
+	/// Creates a new <see cref="PatternPropertiesKeyword"/>.
+	/// </summary>
+	/// <param name="values">The pattern-keyed schemas.</param>
+	public PatternPropertiesKeyword(IEnumerable<KeyValuePair<Regex, JsonSchema>> values)
+	{
+		_patternsLookup = values.ToDictionary(x => x.Key.ToString(), x => (new RegexOrPattern(x.Key), JsonPointer.Create(Name, x.Key.ToString()), x.Value), StringComparer.Ordinal);
 	}
 
 	/// <summary>
@@ -76,16 +89,19 @@ public class PatternPropertiesKeyword : IJsonSchemaKeyword, IKeyedSchemaCollecto
 	/// <returns>A constraint object.</returns>
 	public KeywordConstraint GetConstraint(SchemaConstraint schemaConstraint, ReadOnlySpan<KeywordConstraint> localConstraints, EvaluationContext context)
 	{
-		var subschemaConstraints = Patterns.Select(pattern =>
+		var subschemaConstraints = _patternsLookup.Select(kvp =>
 		{
-			context.PushEvaluationPath(pattern.Key.ToString());
-			var subschemaConstraint = pattern.Value.GetConstraint(_evaluationPointers[pattern.Key], schemaConstraint.BaseInstanceLocation, JsonPointer.Empty, context);
+			var key = kvp.Key;
+			var (regex, pointer, schema) = kvp.Value;
+
+			context.PushEvaluationPath(key);
+			var subschemaConstraint = schema.GetConstraint(pointer, schemaConstraint.BaseInstanceLocation, JsonPointer.Empty, context);
 			context.PopEvaluationPath();
 			subschemaConstraint.InstanceLocator = evaluation =>
 			{
 				if (evaluation.LocalInstance is not JsonObject obj) return [];
 
-				var properties = obj.Select(x => x.Key).Where(x => pattern.Key.IsMatch(x));
+				var properties = obj.Select(x => x.Key).Where(x => regex.IsMatch(x));
 
 				return properties.Select(x => JsonPointer.Create(x));
 			};
@@ -102,10 +118,12 @@ public class PatternPropertiesKeyword : IJsonSchemaKeyword, IKeyedSchemaCollecto
 	private static void Evaluator(KeywordEvaluation evaluation, EvaluationContext context)
 	{
 		evaluation.Results.SetAnnotation(Name, evaluation.ChildEvaluations.Select(x => (JsonNode)x.RelativeInstanceLocation[0]).ToJsonArray());
-		
+
 		if (!evaluation.ChildEvaluations.All(x => x.Results.IsValid))
 			evaluation.Results.Fail();
 	}
+
+	internal IEnumerable<(string Pattern, JsonSchema Schema)> EnumeratePropertyPatterns() => _patternsLookup.Select(x => (x.Key, x.Value.Schema));
 }
 
 /// <summary>
@@ -124,21 +142,7 @@ public sealed class PatternPropertiesKeywordJsonConverter : WeaklyTypedJsonConve
 			throw new JsonException("Expected object");
 
 		var patternProps = options.ReadDictionary(ref reader, JsonSchemaSerializerContext.Default.JsonSchema)!;
-		var schemas = new Dictionary<Regex, JsonSchema>();
-		var invalidProps = new List<string>();
-		foreach (var prop in patternProps)
-		{
-			try
-			{
-				var regex = new Regex(prop.Key, RegexOptions.ECMAScript | RegexOptions.Compiled);
-				schemas.Add(regex, prop.Value);
-			}
-			catch
-			{
-				invalidProps.Add(prop.Key);
-			}
-		}
-		return new PatternPropertiesKeyword(schemas, invalidProps);
+		return new PatternPropertiesKeyword(patternProps);
 	}
 
 	/// <summary>Writes a specified value as JSON.</summary>
@@ -148,10 +152,10 @@ public sealed class PatternPropertiesKeywordJsonConverter : WeaklyTypedJsonConve
 	public override void Write(Utf8JsonWriter writer, PatternPropertiesKeyword value, JsonSerializerOptions options)
 	{
 		writer.WriteStartObject();
-		foreach (var schema in value.Patterns)
+		foreach (var (pattern, schema) in value.EnumeratePropertyPatterns())
 		{
-			writer.WritePropertyName(schema.Key.ToString());
-			options.Write(writer, schema.Value, JsonSchemaSerializerContext.Default.JsonSchema);
+			writer.WritePropertyName(pattern);
+			options.Write(writer, schema, JsonSchemaSerializerContext.Default.JsonSchema);
 		}
 		writer.WriteEndObject();
 	}

--- a/src/JsonSchema/PatternPropertiesKeyword.cs
+++ b/src/JsonSchema/PatternPropertiesKeyword.cs
@@ -32,14 +32,23 @@ public class PatternPropertiesKeyword : IJsonSchemaKeyword, IKeyedSchemaCollecto
 	/// </summary>
 	public const string Name = "patternProperties";
 
-	private Dictionary<string, JsonSchema>? _patterns;
+	private Dictionary<string, JsonSchema>? _patternValues;
+	
+	private Dictionary<Regex, JsonSchema>? _patterns;
 
 	/// <summary>
-	/// The patterns of this PatternPropertiesKeyword
+	/// The pattern values of this PatternPropertiesKeyword
 	/// </summary>
-	public IReadOnlyDictionary<string, JsonSchema> Patterns => _patterns ??= _patternsLookup.ToDictionary(x => x.Key, x => x.Value.Schema);
+	public IReadOnlyDictionary<string, JsonSchema> PatternValues => _patternValues ??= _patternsLookup.ToDictionary(x => x.Key, x => x.Value.Schema);
+	
+	/// <summary>
+	/// The regex patterns of this PatternPropertiesKeyword
+	/// </summary>
+	[Obsolete($"Please use the '{nameof(PatternValues)}' instead.")]
+	public IReadOnlyDictionary<Regex, JsonSchema> Patterns => _patterns ??= _patternsLookup.ToDictionary(x => x.Value.Regex.ToRegex(), x => x.Value.Schema);
 
-	IReadOnlyDictionary<string, JsonSchema> IKeyedSchemaCollector.Schemas => Patterns;
+
+	IReadOnlyDictionary<string, JsonSchema> IKeyedSchemaCollector.Schemas => PatternValues;
 
 	/// <summary>
 	/// Creates a new <see cref="PatternPropertiesKeyword"/>.

--- a/src/JsonSchema/RegexFormat.cs
+++ b/src/JsonSchema/RegexFormat.cs
@@ -50,7 +50,7 @@ public class RegexFormat : Format
 		var str = node!.GetValue<string>();
 		var isMatch =  _regex.IsMatch(str);
 
-		if (isMatch)
+		if (!isMatch)
 		{
 			errorMessage = $"Value is not a match for the format '{Key}'.";
 			return false;

--- a/src/JsonSchema/RegexFormat.cs
+++ b/src/JsonSchema/RegexFormat.cs
@@ -9,7 +9,7 @@ namespace Json.Schema;
 /// </summary>
 public class RegexFormat : Format
 {
-	private readonly Regex _regex;
+	private readonly string _regex;
 
 	/// <summary>
 	/// Creates a new <see cref="RegexFormat"/>.
@@ -19,7 +19,7 @@ public class RegexFormat : Format
 	public RegexFormat(string key, [StringSyntax(StringSyntaxAttribute.Regex)] string regex)
 		: base(key)
 	{
-		_regex = new Regex(regex, RegexOptions.ECMAScript | RegexOptions.Compiled);
+		_regex = regex;
 	}
 
 	/// <summary>
@@ -37,7 +37,7 @@ public class RegexFormat : Format
 		}
 
 		var str = node!.GetValue<string>();
-		var matches = _regex.Match(str);
+		var matches = Regex.Match(str, _regex, RegexOptions.Compiled | RegexOptions.ECMAScript);
 
 		if (matches.Value != str)
 		{

--- a/src/JsonSchema/RegexFormat.cs
+++ b/src/JsonSchema/RegexFormat.cs
@@ -9,7 +9,7 @@ namespace Json.Schema;
 /// </summary>
 public class RegexFormat : Format
 {
-	private readonly string _regex;
+	private readonly RegexOrPattern _regex;
 
 	/// <summary>
 	/// Creates a new <see cref="RegexFormat"/>.
@@ -17,6 +17,17 @@ public class RegexFormat : Format
 	/// <param name="key">The format key.</param>
 	/// <param name="regex">The regular expression.</param>
 	public RegexFormat(string key, [StringSyntax(StringSyntaxAttribute.Regex)] string regex)
+		: base(key)
+	{
+		_regex = regex;
+	}
+
+	/// <summary>
+	/// Creates a new <see cref="RegexFormat"/>.
+	/// </summary>
+	/// <param name="key">The format key.</param>
+	/// <param name="regex">The regular expression.</param>
+	public RegexFormat(string key, Regex regex)
 		: base(key)
 	{
 		_regex = regex;
@@ -37,15 +48,15 @@ public class RegexFormat : Format
 		}
 
 		var str = node!.GetValue<string>();
-		var matches = Regex.Match(str, _regex, RegexOptions.Compiled | RegexOptions.ECMAScript);
+		var isMatch =  _regex.IsMatch(str);
 
-		if (matches.Value != str)
+		if (isMatch)
 		{
 			errorMessage = $"Value is not a match for the format '{Key}'.";
 			return false;
 		}
 
 		errorMessage = null;
-		return matches.Value == str;
+		return isMatch;
 	}
 }

--- a/src/JsonSchema/RegexOrPattern.cs
+++ b/src/JsonSchema/RegexOrPattern.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace Json.Schema;
+
+/// <summary>
+/// a union type based on either a Regex instance or a Pattern
+/// </summary>
+internal readonly struct RegexOrPattern
+{
+	private readonly string _pattern;
+	private readonly Regex _regex;
+
+	public RegexOrPattern(string pattern)
+	{
+		_pattern = pattern?.Replace("{Letter}", "{L}").Replace("{digit}", "{Nd}") ?? throw new ArgumentNullException(nameof(pattern));
+	}
+
+	public RegexOrPattern(Regex regex)
+	{
+		if (regex == null) throw new ArgumentNullException(nameof(regex));
+		_pattern = regex.ToString();
+		_regex = regex;
+	}
+
+	/// <summary>
+	/// Determines is the string matches the specified pattern.
+	/// </summary>
+	/// <param name="str"></param>
+	/// <returns></returns>
+	public bool IsMatch(string str)
+	{
+		return _regex?.IsMatch(str) ?? Regex.IsMatch(str, _pattern, RegexOptions.Compiled | RegexOptions.ECMAScript, TimeSpan.FromSeconds(5));
+	}
+
+	public static implicit operator string(RegexOrPattern regexOrPattern)
+	{
+		return regexOrPattern.ToString();
+	}
+
+	public static implicit operator RegexOrPattern(string pattern)
+	{
+		return new RegexOrPattern(pattern);
+	}
+
+	public static implicit operator RegexOrPattern(Regex regex)
+	{
+		return new RegexOrPattern(regex);
+	}
+
+	public override bool Equals(object? obj)
+	{
+		return obj is RegexOrPattern other && Equals(other);
+	}
+
+	public bool Equals(RegexOrPattern other)
+	{
+		return string.Equals(_pattern, other._pattern, StringComparison.Ordinal);
+	}
+
+	public override int GetHashCode()
+	{
+		return _pattern.GetHashCode();
+	}
+
+	/// <summary>
+	/// Will return the original Regex that created this instance, or it will return a new Regex based on the pattern.
+	/// </summary>
+	/// <returns></returns>
+	public Regex ToRegex() => _regex ?? new Regex(_pattern, RegexOptions.ECMAScript, TimeSpan.FromSeconds(5));
+
+	/// <summary>
+	/// Returns the regex pattern
+	/// </summary>
+	/// <returns></returns>
+	public override string ToString()
+	{
+		return _pattern;
+	}
+}


### PR DESCRIPTION
### Description

Improved usage of `Regex` in several places.

When a `string` pattern is supplied for `Pattern` or `PatterProperties` keywords, the static `Regex.IsMatch` will be used to evaluate the keywords. 

When a `Regex` instance is supplied, that instance is used by the keywords.

I also made the `_dateTimeRegex` a compiled regex to improve performance. (this could be improved further by using code generated regex instances.)

Updated the `Formats` class to use code generated regex if possible.

## breaking changes

* The return type of `JsonSchemaExtensions.KeywordAccess` `GetPattern` and `GetPatternProperties` will return the `string` pattern and not the `Regex` instance.
* The  `Regex Value` property in the `PatternKeyword` was removed, in favor of a `string Pattern` property. 
* The `PatternPropertiesKeyword.Patterns` property changed from an `IReadOnlyDictionary<Regex, JsonSchema>` to ` IReadOnlyDictionary<string, JsonSchema>`

### Links

Resolves #761  

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
