### PR TITLE
updated test suite; fixed equality of nothing; fixed `\u` parsing

### DIFF
--- a/src/JsonPath/Expressions/EqualToOperator.cs
+++ b/src/JsonPath/Expressions/EqualToOperator.cs
@@ -11,9 +11,11 @@ internal class EqualToOperator : IBinaryComparativeOperator
 		if (left is null) return right is null;
 		if (right is null) return false;
 
-		if (!left.TryGetJson(out var lNode) ||
-		    !right.TryGetJson(out var rNode))
-			return false;
+		var lSuccess = left.TryGetJson(out var lNode) && !ReferenceEquals(lNode, ValueFunctionDefinition.Nothing);
+		var rSuccess = right.TryGetJson(out var rNode) && !ReferenceEquals(rNode, ValueFunctionDefinition.Nothing);
+
+		if (!lSuccess && !rSuccess) return true;
+		if (!lSuccess || !rSuccess) return false;
 
 		return lNode.IsEquivalentTo(rNode);
 	}

--- a/src/JsonPath/Expressions/NotEqualToOperator.cs
+++ b/src/JsonPath/Expressions/NotEqualToOperator.cs
@@ -11,9 +11,11 @@ internal class NotEqualToOperator : IBinaryComparativeOperator
 		if (left is null) return right is not null;
 		if (right is null) return true;
 
-		if (!left.TryGetJson(out var lNode) ||
-		    !right.TryGetJson(out var rNode))
-			return true;
+		var lSuccess = left.TryGetJson(out var lNode) && !ReferenceEquals(lNode, ValueFunctionDefinition.Nothing);
+		var rSuccess = right.TryGetJson(out var rNode) && !ReferenceEquals(rNode, ValueFunctionDefinition.Nothing);
+
+		if (!lSuccess && !rSuccess) return false;
+		if (!lSuccess || !rSuccess) return true;
 
 		return !lNode.IsEquivalentTo(rNode);
 	}

--- a/src/JsonPath/IPathFunctionDefinition.cs
+++ b/src/JsonPath/IPathFunctionDefinition.cs
@@ -32,10 +32,7 @@ public abstract partial class ValueFunctionDefinition : IReflectiveFunctionDefin
 	private class NothingValue;
 
 	[JsonSerializable(typeof(NothingValue))]
-	private partial class NothingValueContext : JsonSerializerContext
-	{
-
-	}
+	private partial class NothingValueContext : JsonSerializerContext;
 
 	/// <summary>
 	/// Represents the absence of a JSON value and is distinct from any JSON value, including null.

--- a/src/JsonPath/JsonPath.csproj
+++ b/src/JsonPath/JsonPath.csproj
@@ -15,8 +15,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>JsonPath.Net</PackageId>
-    <Version>1.1.2</Version>
-    <FileVersion>1.1.2</FileVersion>
+    <Version>1.1.3</Version>
+    <FileVersion>1.1.3</FileVersion>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>JSON Path (RFC 9535) built on the System.Text.Json namespace</Description>

--- a/src/JsonPath/NameSelector.cs
+++ b/src/JsonPath/NameSelector.cs
@@ -173,7 +173,6 @@ internal class NameSelectorParser : ISelectorParser
 				i++;
 				break;
 			case 'u':
-			case 'U':
 				var hexStart = i;
 				while (ReadHexCode(source, ref i) && source[i] == '\\')
 				{
@@ -203,12 +202,13 @@ internal class NameSelectorParser : ISelectorParser
 	private static bool ReadHexCode(ReadOnlySpan<char> source, ref int i)
 	{
 		// reads uXXXX
-		if (source[i] is not 'u' or 'U') return false;
+		if (source[i] != 'u') return false;
 
-		i++; // consume u
-		if (source[i..(i + 4)].ToArray().All(x => char.ToUpper(x) is (>= 'A' and <= 'F') or (>= '0' and <= '9')))
+		var j = i;
+		j++; // consume u
+		if (j + 4 <= source.Length && source[j..(j + 4)].ToArray().All(x => char.ToUpper(x) is (>= 'A' and <= 'F') or (>= '0' and <= '9')))
 		{
-			i += 4;
+			i = j + 4;
 			return true;
 		}
 

--- a/tools/ApiDocsGenerator/release-notes/rn-json-path.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-path.md
@@ -4,6 +4,12 @@ title: JsonPath.Net
 icon: fas fa-tag
 order: "09.08"
 ---
+# [1.1.3](https://github.com/gregsdennis/json-everything/pull/774) {#release-path-1.1.3}
+
+[JSON Path Test Suite #86](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/86) - Invalid `\u` escapes will error correctly.  Previously, an unexpected exception would be thrown.
+
+[JSON Path Test Suite #84](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/84) - Equality comparisons (`==` and `!=`) between `Nothing` and empty nodelists incorrectly returning false.
+
 # [1.1.2](https://github.com/gregsdennis/json-everything/pull/750) {#release-path-1.1.2}
 
 - Improved parsing to account for a few missed scenarios involving math operations.


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

- updated test suite
- fixed equality of nothing
- fixed `\u` parsing

### Links

- Relates to https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/84
- Relates to https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/86

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
