### PR TITLE
Handle more updates to JSON Path test suite

### DIFF
--- a/src/JsonPath/JsonPath.csproj
+++ b/src/JsonPath/JsonPath.csproj
@@ -15,8 +15,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>JsonPath.Net</PackageId>
-    <Version>1.1.3</Version>
-    <FileVersion>1.1.3</FileVersion>
+    <Version>1.1.4</Version>
+    <FileVersion>1.1.4</FileVersion>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>JSON Path (RFC 9535) built on the System.Text.Json namespace</Description>

--- a/src/JsonPath/NameSelector.cs
+++ b/src/JsonPath/NameSelector.cs
@@ -182,8 +182,16 @@ internal class NameSelectorParser : ISelectorParser
 				if (hexStart == i) return false;
 
 				// this is simpler than trying to parse and calc surrogates myself.
-				var hexEncodedChars = JsonNode.Parse($"\"{source[(hexStart-1)..i].ToString()}\"")!;
-				sb.Append(hexEncodedChars.GetValue<string>());
+				// but it does throw an InvalidOperationException when the encoded char is invalid...
+				try
+				{
+					var hexEncodedChars = JsonNode.Parse($"\"{source[(hexStart-1)..i].ToString()}\"")!;
+					sb.Append(hexEncodedChars.GetValue<string>());
+				}
+				catch (InvalidOperationException)
+				{
+					return false;
+				}
 				break;
 			default:
 				if (source[i] == quoteChar)

--- a/src/JsonPath/NameSelector.cs
+++ b/src/JsonPath/NameSelector.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace Json.Path;
@@ -188,7 +189,7 @@ internal class NameSelectorParser : ISelectorParser
 					var hexEncodedChars = JsonNode.Parse($"\"{source[(hexStart-1)..i].ToString()}\"")!;
 					sb.Append(hexEncodedChars.GetValue<string>());
 				}
-				catch (InvalidOperationException)
+				catch (Exception e) when (e  is InvalidOperationException or JsonException)
 				{
 					return false;
 				}

--- a/src/JsonPath/SpanExtensions.cs
+++ b/src/JsonPath/SpanExtensions.cs
@@ -105,10 +105,10 @@ internal static class SpanExtensions
 					end = i;
 					var allowDash = true;
 					while (end < span.Length && (span[end].In('0'..('9' + 1)) ||
-												 span[end].In('e', '.', '-', '+')))
+												 span[end].In('e', 'E', '.', '-', '+')))
 					{
 						if (!allowDash && span[end] is '-' or '+') break;
-						allowDash = span[end] is 'e';
+						allowDash = span[end] is 'e' or 'E';
 						end++;
 					}
 					break;

--- a/src/JsonPath/SpanExtensions.cs
+++ b/src/JsonPath/SpanExtensions.cs
@@ -20,6 +20,9 @@ internal static class SpanExtensions
 		//throw new PathParseException(i, "Characters in the range U+0000..U+001F are disallowed");
 	}
 
+	private const long _minInteger = -(2L << 52); // -(2^53)
+	private const long _maxInteger = 2L << 52; // 2^53
+
 	public static bool TryGetInt(this ReadOnlySpan<char> span, ref int index, out int value)
 	{
 		var negative = false;
@@ -47,7 +50,7 @@ internal static class SpanExtensions
 			if (!overflowed)
 			{
 				parsedValue = parsedValue * 10 + span[i] - '0';
-				overflowed = parsedValue is <= -2L << 53 or >= 2L << 53;
+				overflowed = parsedValue is <= _minInteger or >= _maxInteger;
 			}
 
 			i++;
@@ -55,7 +58,11 @@ internal static class SpanExtensions
 
 		if (overflowed) return false;
 
-		if (negative) parsedValue = -parsedValue;
+		if (negative)
+		{
+			if (parsedValue == 0) return false;
+			parsedValue = -parsedValue;
+		}
 
 		index = i;
 		value = (int)Math.Min(int.MaxValue, Math.Max(int.MinValue, parsedValue));
@@ -101,7 +108,7 @@ internal static class SpanExtensions
 												 span[end].In('e', '.', '-', '+')))
 					{
 						if (!allowDash && span[end] is '-' or '+') break;
-						allowDash = span[end] == 'e';
+						allowDash = span[end] is 'e';
 						end++;
 					}
 					break;

--- a/tools/ApiDocsGenerator/release-notes/rn-json-path.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-path.md
@@ -4,11 +4,22 @@ title: JsonPath.Net
 icon: fas fa-tag
 order: "09.08"
 ---
+# [1.1.4](https://github.com/gregsdennis/json-everything/pull/774) {#release-path-1.1.3}
+
+Some of these new tests found bugs.
+
+- [JSON Path Test Suite #87](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/87) - Invalid surrogate pairs.
+- [JSON Path Test Suite #88](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/88) - Unescaped delete char (JSON Path should support it).
+- [JSON Path Test Suite #89](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/89) - Invalid and uncommon filter literal values.
+- [JSON Path Test Suite #90](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/90) - Numeric value boundary checking.
+
+Thanks to [@Marcono1234](https://github.com/Marcono1234) for adding all of these fantastic tests (and the ones for 1.1.3) to the JSON Path Test Suite!
+
+
 # [1.1.3](https://github.com/gregsdennis/json-everything/pull/774) {#release-path-1.1.3}
 
-[JSON Path Test Suite #86](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/86) - Invalid `\u` escapes will error correctly.  Previously, an unexpected exception would be thrown.
-
-[JSON Path Test Suite #84](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/84) - Equality comparisons (`==` and `!=`) between `Nothing` and empty nodelists incorrectly returning false.
+- [JSON Path Test Suite #86](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/86) - Invalid `\u` escapes will error correctly.  Previously, an unexpected exception would be thrown.
+- [JSON Path Test Suite #84](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/84) - Equality comparisons (`==` and `!=`) between `Nothing` and empty nodelists incorrectly returning false.
 
 # [1.1.2](https://github.com/gregsdennis/json-everything/pull/750) {#release-path-1.1.2}
 

--- a/tools/ApiDocsGenerator/release-notes/rn-json-path.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-path.md
@@ -4,7 +4,7 @@ title: JsonPath.Net
 icon: fas fa-tag
 order: "09.08"
 ---
-# [1.1.4](https://github.com/gregsdennis/json-everything/pull/774) {#release-path-1.1.3}
+# [1.1.4](https://github.com/gregsdennis/json-everything/pull/775) {#release-path-1.1.4}
 
 Some of these new tests found bugs.
 


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

<!--
Please add a short description of the changes.  Be sure to include:
  - whether this affects the public API surface
  - whether the changes cause breaks in either developer experience or behavior
-->
More updates to the JSON Path test suite found more bugs.  Thanks to [@Marcono1234](https://github.com/Marcono1234) for adding these scenarios.

### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
Relates to https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/87

Depends on https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/88
Depends on https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/89
Depends on https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/90

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
