### PR TITLE
Count subschemas before memory allocation

### DIFF
--- a/src/JsonSchema/EvaluationContext.cs
+++ b/src/JsonSchema/EvaluationContext.cs
@@ -50,15 +50,6 @@ public class EvaluationContext
 		Scope = new DynamicScope(initialScope);
 	}
 
-	internal static IEnumerable<IJsonSchemaKeyword> GetKeywordsToProcess(JsonSchema schema, EvaluationOptions options)
-	{
-		if (options.ProcessCustomKeywords ||
-		    schema.Dialect == null) return schema.Keywords!;
-
-		var vocabKeywordTypes = schema.Dialect.SelectMany(x => x?.Keywords ?? []);
-		return schema.Keywords!.Where(x => vocabKeywordTypes.Contains(x.GetType()));
-	}
-
 	internal void PushEvaluatingAs(SpecVersion version)
 	{
 		_evaluatingAs.Push(version);

--- a/src/JsonSchema/JsonSchema.cs
+++ b/src/JsonSchema/JsonSchema.cs
@@ -345,6 +345,13 @@ public class JsonSchema : IBaseDocument
 			}
 		}
 
+		if (_subschemas is null)
+		{
+			using var owner = MemoryPool<JsonSchema>.Shared.Rent(CountSubschemas());
+			_ = GetSubschemas(owner);
+			if (_subschemas is null) return false;
+		}
+
 		foreach (var subschema in _subschemas!)
 		{
 			if (subschema.IsDynamic())

--- a/src/JsonSchema/JsonSchema.cs
+++ b/src/JsonSchema/JsonSchema.cs
@@ -317,8 +317,14 @@ public class JsonSchema : IBaseDocument
 
 	private void ClearConstraints()
 	{
-		using var owner = MemoryPool<JsonSchema>.Shared.Rent();
-		foreach (var subschema in GetSubschemas(owner))
+		if (_subschemas is null)
+		{
+			using var owner = MemoryPool<JsonSchema>.Shared.Rent(CountSubschemas());
+			_ = GetSubschemas(owner);
+			if (_subschemas is null) return;
+		}
+
+		foreach (var subschema in _subschemas!)
 		{
 			subschema.ClearConstraints();
 		}
@@ -339,8 +345,7 @@ public class JsonSchema : IBaseDocument
 			}
 		}
 
-		using var owner = MemoryPool<JsonSchema>.Shared.Rent();
-		foreach (var subschema in GetSubschemas(owner))
+		foreach (var subschema in _subschemas!)
 		{
 			if (subschema.IsDynamic())
 			{
@@ -526,13 +531,37 @@ public class JsonSchema : IBaseDocument
 		return keyword.SupportsVersion(preferredVersion);
 	}
 
+	private JsonSchema[]? _subschemas;
+
+	internal int CountSubschemas()
+	{
+		if (BoolValue.HasValue) return 0;
+		if (_subschemas is not null) return _subschemas.Length;
+
+		return Keywords!.Sum(CountSubschemas);
+	}
+
+	private static int CountSubschemas(IJsonSchemaKeyword keyword)
+	{
+		return keyword switch
+		{
+			// ReSharper disable once RedundantAlwaysMatchSubpattern
+			ISchemaContainer { Schema: not null } container => 1 + container.Schema.CountSubschemas(),
+			ISchemaCollector collector => collector.Schemas.Count + collector.Schemas.Sum(x => x.CountSubschemas()),
+			IKeyedSchemaCollector collector => collector.Schemas.Count + collector.Schemas.Values.Sum(x => x.CountSubschemas()),
+			ICustomSchemaCollector collector => collector.Schemas.Count() + collector.Schemas.Sum(x => x.CountSubschemas()),
+			_ => 0
+		};
+	}
+
 	internal ReadOnlySpan<JsonSchema> GetSubschemas(IMemoryOwner<JsonSchema> owner)
 	{
 		if (BoolValue.HasValue) return [];
+		if (_subschemas is not null) return _subschemas;
 
 		var span = owner.Memory.Span;
 
-		using var keywordOwner = MemoryPool<JsonSchema>.Shared.Rent();
+		using var keywordOwner = MemoryPool<JsonSchema>.Shared.Rent(100000);
 		var i = 0;
 		foreach (var keyword in Keywords!)
 		{
@@ -542,6 +571,8 @@ public class JsonSchema : IBaseDocument
 				i++;
 			}
 		}
+
+		_subschemas = i == 0 ? [] : span[..i].ToArray();
 
 		return i == 0 ? [] : span[..i];
 	}

--- a/src/JsonSchema/JsonSchema.csproj
+++ b/src/JsonSchema/JsonSchema.csproj
@@ -17,8 +17,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>JsonSchema.Net</PackageId>
-    <Version>7.2.0</Version>
-    <FileVersion>7.2.0</FileVersion>
+    <Version>7.2.1</Version>
+    <FileVersion>7.2.1</FileVersion>
     <AssemblyVersion>7.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>JSON Schema built on the System.Text.Json namespace</Description>

--- a/src/JsonSchema/SchemaRegistry.cs
+++ b/src/JsonSchema/SchemaRegistry.cs
@@ -377,7 +377,7 @@ public class SchemaRegistry
 				registration.Anchors[anchor] = currentSchema;
 			}
 
-			using var owner = MemoryPool<JsonSchema>.Shared.Rent();
+			using var owner = MemoryPool<JsonSchema>.Shared.Rent(currentSchema.CountSubschemas());
 			foreach (var subschema in currentSchema.GetSubschemas(owner))
 			{
 				if (subschema.BoolValue.HasValue) continue;

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
@@ -4,6 +4,10 @@ title: JsonSchema.Net
 icon: fas fa-tag
 order: "09.01"
 ---
+# [7.2.1](https://github.com/gregsdennis/json-everything/pull/781) {#release-schema-7.2.1}
+
+[#778](https://github.com/gregsdennis/json-everything/issues/778) - Addresses a potential `IndexOutOfRangeException` that could occur for large schemas.  Thanks to [@Laniusexcubitor](https://github.com/Laniusexcubitor) for bouncing ideas and testing.
+
 # [7.2.0](https://github.com/gregsdennis/json-everything/pull/776) {#release-schema-7.2.0}
 
 [#773](https://github.com/gregsdennis/json-everything/issues/773) - [@rikbosch](https://github.com/rikbosch) recommended and patched a performance improvement around regular expression handling.

--- a/tools/Benchmarks/SchemaSuite/TestSuiteRunner.cs
+++ b/tools/Benchmarks/SchemaSuite/TestSuiteRunner.cs
@@ -13,7 +13,7 @@ namespace Json.Benchmarks.SchemaSuite;
 [MemoryDiagnoser]
 public class TestSuiteRunner
 {
-	private const string _benchmarkOffset = @"../../../../";
+	private const string _benchmarkOffset = @"../../../../../";
 	private const string _testCasesPath = @"../../../../ref-repos/JSON-Schema-Test-Suite/tests";
 	private const string _remoteSchemasPath = @"../../../../ref-repos/JSON-Schema-Test-Suite/remotes";
 
@@ -107,7 +107,7 @@ public class TestSuiteRunner
 	[Benchmark]
 	[Arguments(1)]
 	[Arguments(10)]
-	public int RunSuite_Legacy(int n)
+	public int StatusQuo(int n)
 	{
 		int i = 0;
 		var collections = GetAllTests();


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

Schemas which have more than 512 subschemas will throw an `IndexOutOfRangeException` during registration.

cc: @Laniusexcubitor

### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
Resolves #778     <!-- Use if these changes completely resolve the issue -->

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
