### PR TITLE
unevaluated* duplicating pointer segments in instance location

### DIFF
--- a/src/JsonSchema.Tests/OutputTests.cs
+++ b/src/JsonSchema.Tests/OutputTests.cs
@@ -503,7 +503,7 @@ public class OutputTests
 	public void AdditionalItemsDoesNotGiveExtraErrors()
 	{
 		JsonSchema schema = new JsonSchemaBuilder()
-			.Items(new JsonSchema[] { true, false })
+			.Items([true, false ])
 			.AdditionalItems(false);
 
 		var instance = JsonNode.Parse("[1,2]");
@@ -521,7 +521,7 @@ public class OutputTests
 	{
 		JsonSchema schema = new JsonSchemaBuilder()
 			.Schema(MetaSchemas.Draft201909Id)
-			.Items(new JsonSchema[] { true, false })
+			.Items([true, false])
 			.UnevaluatedItems(false);
 
 		var instance = JsonNode.Parse("[1,2]");

--- a/src/JsonSchema.Tests/OutputTests.cs
+++ b/src/JsonSchema.Tests/OutputTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Json.Pointer;
 using NUnit.Framework;
 
 namespace Json.Schema.Tests;
@@ -458,6 +460,43 @@ public class OutputTests
 		Console.WriteLine(serialized);
 
 		Assert.That(serialized, Does.Contain("unevaluatedProperties"));
+	}
+
+	[Test]
+	public void UnevaluatedPropertiesGivesCorrectInstanceLocation()
+	{
+		JsonSchema schema = new JsonSchemaBuilder()
+			.Properties(("foo", true))
+			.UnevaluatedProperties(false);
+
+		var instance = JsonNode.Parse("{\"foo\": null, \"bar\": null}");
+
+		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List });
+
+		var serialized = JsonSerializer.Serialize(result, TestEnvironment.TestOutputSerializerOptions);
+		Console.WriteLine(serialized);
+
+		var unevaluatedPropertiesResult = result.Details.Single(x => x.EvaluationPath.Equals(JsonPointer.Create("unevaluatedProperties")));
+		Assert.That(unevaluatedPropertiesResult.InstanceLocation.ToString(), Is.EqualTo("/bar"));
+	}
+
+
+	[Test]
+	public void UnevaluatedItemsGivesCorrectInstanceLocation()
+	{
+		JsonSchema schema = new JsonSchemaBuilder()
+			.PrefixItems(true)
+			.UnevaluatedItems(false);
+
+		var instance = JsonNode.Parse("[1, 2]");
+
+		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List });
+
+		var serialized = JsonSerializer.Serialize(result, TestEnvironment.TestOutputSerializerOptions);
+		Console.WriteLine(serialized);
+
+		var unevaluatedPropertiesResult = result.Details.Single(x => x.EvaluationPath.Equals(JsonPointer.Create("unevaluatedItems")));
+		Assert.That(unevaluatedPropertiesResult.InstanceLocation.ToString(), Is.EqualTo("/1"));
 	}
 
 	[Test]

--- a/src/JsonSchema/JsonSchema.csproj
+++ b/src/JsonSchema/JsonSchema.csproj
@@ -17,8 +17,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>JsonSchema.Net</PackageId>
-    <Version>7.2.1</Version>
-    <FileVersion>7.2.1</FileVersion>
+    <Version>7.2.2</Version>
+    <FileVersion>7.2.2</FileVersion>
     <AssemblyVersion>7.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>JSON Schema built on the System.Text.Json namespace</Description>

--- a/src/JsonSchema/UnevaluatedItemsKeyword.cs
+++ b/src/JsonSchema/UnevaluatedItemsKeyword.cs
@@ -117,7 +117,7 @@ public class UnevaluatedItemsKeyword : IJsonSchemaKeyword, ISchemaContainer
 
 		var childEvaluations = indicesToEvaluate
 			.Select(i => (Index: i, Constraint: Schema.GetConstraint(JsonPointer.Create(Name), evaluation.Results.InstanceLocation, JsonPointer.Create(i), context)))
-			.Select(x => x.Constraint.BuildEvaluation(array[x.Index], evaluation.Results.InstanceLocation.Combine(x.Index), evaluation.Results.EvaluationPath, context.Options))
+			.Select(x => x.Constraint.BuildEvaluation(array[x.Index], evaluation.Results.InstanceLocation, evaluation.Results.EvaluationPath, context.Options))
 			.ToArray();
 
 		evaluation.ChildEvaluations = childEvaluations;

--- a/src/JsonSchema/UnevaluatedPropertiesKeyword.cs
+++ b/src/JsonSchema/UnevaluatedPropertiesKeyword.cs
@@ -98,7 +98,7 @@ public class UnevaluatedPropertiesKeyword : IJsonSchemaKeyword, ISchemaContainer
 
 		var childEvaluations = properties
 			.Select(x => (Name: x, Constraint: Schema.GetConstraint(JsonPointer.Create(Name), evaluation.Results.InstanceLocation, JsonPointer.Create(x), context)))
-			.Select(x => x.Constraint.BuildEvaluation(obj[x.Name], evaluation.Results.InstanceLocation.Combine(x.Name), evaluation.Results.EvaluationPath, context.Options))
+			.Select(x => x.Constraint.BuildEvaluation(obj[x.Name], evaluation.Results.InstanceLocation, evaluation.Results.EvaluationPath, context.Options))
 			.ToArray();
 
 		evaluation.ChildEvaluations = childEvaluations;

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
@@ -4,6 +4,10 @@ title: JsonSchema.Net
 icon: fas fa-tag
 order: "09.01"
 ---
+# [7.2.2](https://github.com/gregsdennis/json-everything/pull/782) {#release-schema-7.2.2}
+
+Fixes an issue with `unevaluated*` keyword output where the instance location would contain repeated pointer segments.
+
 # [7.2.1](https://github.com/gregsdennis/json-everything/pull/781) {#release-schema-7.2.1}
 
 [#778](https://github.com/gregsdennis/json-everything/issues/778) - Addresses a potential `IndexOutOfRangeException` that could occur for large schemas.  Thanks to [@Laniusexcubitor](https://github.com/Laniusexcubitor) for bouncing ideas and testing.


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

The `unevaluated*` keywords are duplicating their pointer segment for the instance location in the output.

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
