### PR TITLE
Users/2BitSalute/issue795_ignore_enum_member

### DIFF
--- a/src/JsonSchema.Generation.Tests/SchemaGenerationTests.cs
+++ b/src/JsonSchema.Generation.Tests/SchemaGenerationTests.cs
@@ -120,6 +120,32 @@ public class SchemaGenerationTests
 		AssertEqual(expected, actual);
 	}
 
+	private enum GenerationTargetEnumeration
+	{
+		[JsonIgnore]
+		IgnoreThis,
+
+		[JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+		DontIgnoreThis,
+
+		[JsonExclude]
+		IgnoreThisWithJsonExclude,
+
+		[JsonIgnore]
+		[JsonExclude]
+		IgnoreThisBoth,
+
+		[JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+		[JsonExclude]
+		Ignore_ExcludesTrumpsIgnore,
+
+		[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+		NeverIgnoreWhenWritingDefault,
+
+		[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+		NeverIgnoreWhenWritingNull,
+	}
+
 	// ReSharper disable once ClassNeverInstantiated.Local
 	// ReSharper disable UnusedMember.Local
 	private class GenerationTarget
@@ -130,6 +156,8 @@ public class SchemaGenerationTests
 
 		private int _notIncluded;
 #pragma warning restore 169
+
+		public GenerationTargetEnumeration EnumProp { get; set; }
 
 		[Required]
 		[Minimum(5)]
@@ -229,6 +257,7 @@ public class SchemaGenerationTests
 			.Type(SchemaValueType.Object)
 			.Properties(
 				("_value", new JsonSchemaBuilder().Type(SchemaValueType.Integer)),
+				("EnumProp", new JsonSchemaBuilder().Enum("DontIgnoreThis", "NeverIgnoreWhenWritingDefault", "NeverIgnoreWhenWritingNull")),
 				("Integer", new JsonSchemaBuilder()
 					.Type(SchemaValueType.Integer)
 					.Minimum(5)

--- a/src/JsonSchema.Generation.Tests/SchemaGenerationTests.cs
+++ b/src/JsonSchema.Generation.Tests/SchemaGenerationTests.cs
@@ -133,11 +133,15 @@ public class SchemaGenerationTests
 
 		[JsonIgnore]
 		[JsonExclude]
-		IgnoreThisBoth,
+		IgnoreAndExcludeThis,
 
 		[JsonIgnore(Condition = JsonIgnoreCondition.Never)]
 		[JsonExclude]
-		Ignore_ExcludesTrumpsIgnore,
+		ExcludeTrumpsIgnore,
+
+		[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+		[JsonExclude]
+		ExcludeTrumpsIgnoreWhenWritingDefault,
 
 		[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
 		DontIgnoreThisWhenWritingDefault,
@@ -212,15 +216,15 @@ public class SchemaGenerationTests
 
 		[JsonIgnore]
 		[JsonExclude]
-		public double IgnoreThisBoth { get; set; }
+		public double IgnoreAndExcludeThis { get; set; }
 
 		[JsonIgnore(Condition = JsonIgnoreCondition.Never)]
 		[JsonExclude]
-		public double Ignore_ExcludesTrumpsIgnore { get; set; }
+		public double ExcludeTrumpsIgnore { get; set; }
 
 		[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
 		[JsonExclude]
-		public double Ignore_ExcludesTrumpsIgnoreWhenWritingDefault { get; set; }
+		public double ExcludeTrumpsIgnoreWhenWritingDefault { get; set; }
 
 
 		[JsonPropertyName("rename-this")]

--- a/src/JsonSchema.Generation.Tests/SchemaGenerationTests.cs
+++ b/src/JsonSchema.Generation.Tests/SchemaGenerationTests.cs
@@ -140,10 +140,10 @@ public class SchemaGenerationTests
 		Ignore_ExcludesTrumpsIgnore,
 
 		[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-		NeverIgnoreWhenWritingDefault,
+		DontIgnoreThisWhenWritingDefault,
 
 		[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-		NeverIgnoreWhenWritingNull,
+		DontIgnoreThisWhenWritingNull,
 	}
 
 	// ReSharper disable once ClassNeverInstantiated.Local
@@ -257,7 +257,8 @@ public class SchemaGenerationTests
 			.Type(SchemaValueType.Object)
 			.Properties(
 				("_value", new JsonSchemaBuilder().Type(SchemaValueType.Integer)),
-				("EnumProp", new JsonSchemaBuilder().Enum("DontIgnoreThis", "NeverIgnoreWhenWritingDefault", "NeverIgnoreWhenWritingNull")),
+				("EnumProp", new JsonSchemaBuilder()
+					.Enum("DontIgnoreThis", "DontIgnoreThisWhenWritingDefault", "DontIgnoreThisWhenWritingNull")),
 				("Integer", new JsonSchemaBuilder()
 					.Type(SchemaValueType.Integer)
 					.Minimum(5)

--- a/src/JsonSchema.Generation/Generators/EnumGenerator.cs
+++ b/src/JsonSchema.Generation/Generators/EnumGenerator.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Text.Json.Serialization;
 using Json.Schema.Generation.Intents;
 

--- a/src/JsonSchema.Generation/Generators/EnumGenerator.cs
+++ b/src/JsonSchema.Generation/Generators/EnumGenerator.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Text.Json.Serialization;
 using Json.Schema.Generation.Intents;
 
 namespace Json.Schema.Generation.Generators;
@@ -14,7 +18,22 @@ internal class EnumGenerator : ISchemaGenerator
 	public void AddConstraints(SchemaGenerationContextBase context)
 	{
 		var values = Enum.GetNames(context.Type).ToList();
+		bool ShouldIncludeMember(string enumValue)
+		{
+			var fieldInfo = context.Type.GetField(enumValue);
+			var fieldAttributes = fieldInfo?.GetCustomAttributes(inherit: true)?.ToList();
 
-		context.Intents.Add(new EnumIntent(values));
+			// JsonIgnoreCondition values other than Never and Always don't make sense in the context of JSON schema generation,
+			// so we only ignore members if they are marked as "always ignored."
+			var ignoreAttribute =
+				(Attribute?)fieldAttributes?.OfType<JsonIgnoreAttribute>().FirstOrDefault(a => a.Condition == JsonIgnoreCondition.Always) ??
+				fieldAttributes?.OfType<JsonExcludeAttribute>().FirstOrDefault();
+
+			return ignoreAttribute == null;
+		};
+
+		var vs = values.Where(ShouldIncludeMember);
+
+		context.Intents.Add(new EnumIntent(vs));
 	}
 }

--- a/src/JsonSchema.Generation/Generators/EnumGenerator.cs
+++ b/src/JsonSchema.Generation/Generators/EnumGenerator.cs
@@ -14,7 +14,6 @@ internal class EnumGenerator : ISchemaGenerator
 
 	public void AddConstraints(SchemaGenerationContextBase context)
 	{
-		var values = Enum.GetNames(context.Type).ToList();
 		bool ShouldIncludeMember(string enumValue)
 		{
 			var fieldInfo = context.Type.GetField(enumValue);
@@ -29,8 +28,7 @@ internal class EnumGenerator : ISchemaGenerator
 			return ignoreAttribute == null;
 		};
 
-		var includedValues = values.Where(ShouldIncludeMember);
-
+		var includedValues = Enum.GetNames(context.Type).Where(ShouldIncludeMember).ToList();
 		context.Intents.Add(new EnumIntent(includedValues));
 	}
 }

--- a/src/JsonSchema.Generation/Generators/EnumGenerator.cs
+++ b/src/JsonSchema.Generation/Generators/EnumGenerator.cs
@@ -29,8 +29,8 @@ internal class EnumGenerator : ISchemaGenerator
 			return ignoreAttribute == null;
 		};
 
-		var vs = values.Where(ShouldIncludeMember);
+		var includedValues = values.Where(ShouldIncludeMember);
 
-		context.Intents.Add(new EnumIntent(vs));
+		context.Intents.Add(new EnumIntent(includedValues));
 	}
 }


### PR DESCRIPTION
### Description

The bug/feature is explained in [issue 795](https://github.com/json-everything/json-everything/issues/795).

This was a small change.

- In `EnumGeneration`, I just used the ignore/exclude conditions in `ObjectSchemaGeneration` 
- In `SchemaGenerationTests`, I added an enum with various attribute combinations, similar to the properties that were already tested, and added an expected schema property

For context, my scenario, which I think is not too uncommon:
- I'm generating a JSON schema for a config file
- I want to be able to use the schema to validate the config in a build step
- I also want users to be able to get IDE services for the JSON, so they can tell if they've specified invalid values
- We have an enum that, according to the [design guidelines](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/enum), specifies a member called `None`, which can be used to test the value to see if it were set or not.
- `None` should not be accepted as a valid value in the config in the build step
- `None` should also not be suggested in the IDE when users are authoring the config

### Links

Resolves https://github.com/json-everything/json-everything/issues/795

### Checks

- [X] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
