### PR TITLE
Fix JsonPath.TryParse to allow relative start, consistent with JsonPa…

### DIFF
--- a/src/JsonPath.Tests/ParsingTests.cs
+++ b/src/JsonPath.Tests/ParsingTests.cs
@@ -139,4 +139,19 @@ public class ParsingTests
 	{
 		Assert.Throws<PathParseException>(() => JsonPath.Parse(path));
 	}
+
+
+
+	[TestCaseSource(nameof(SuccessCases))]
+	public void ParseRelativeStarts(string path)
+	{
+		path = $"@{path[1..]}"; // Turn the absolute path into a relative path
+		Assert.DoesNotThrow(() => JsonPath.Parse(path, new PathParsingOptions(){AllowRelativePathStart = true}));
+	}
+	[TestCaseSource(nameof(SuccessCases))]
+	public void TryParseRelativeStarts(string path)
+	{
+		path = $"@{path[1..]}"; // Turn the absolute path into a relative path
+		Assert.That(JsonPath.TryParse(path, out _, new PathParsingOptions(){AllowRelativePathStart = true}));
+	}
 }

--- a/src/JsonPath.Tests/ParsingTests.cs
+++ b/src/JsonPath.Tests/ParsingTests.cs
@@ -140,14 +140,13 @@ public class ParsingTests
 		Assert.Throws<PathParseException>(() => JsonPath.Parse(path));
 	}
 
-
-
 	[TestCaseSource(nameof(SuccessCases))]
 	public void ParseRelativeStarts(string path)
 	{
 		path = $"@{path[1..]}"; // Turn the absolute path into a relative path
 		Assert.DoesNotThrow(() => JsonPath.Parse(path, new PathParsingOptions(){AllowRelativePathStart = true}));
 	}
+
 	[TestCaseSource(nameof(SuccessCases))]
 	public void TryParseRelativeStarts(string path)
 	{

--- a/src/JsonPath/JsonPath.cs
+++ b/src/JsonPath/JsonPath.cs
@@ -99,7 +99,7 @@ public class JsonPath
 		source = source.Trim();
 
 		int index = 0;
-		if (!PathParser.TryParse(source.AsSpan(), ref index, out path, options, true)) return false;
+		if (!PathParser.TryParse(source.AsSpan(), ref index, out path, options, !options.AllowRelativePathStart)) return false;
 		if (index != source.Length)
 		{
 			path = null;


### PR DESCRIPTION
### Description

There is a discrepancy with how JsonPath.Parse and JsonPath.TryParse handle the PathParsingOptions.AllowRelativePathStart property:

- JsonPath.Parse uses !options.AllowRelativePathStart as the value for PathParser.Parse's requireGlobal parameter. ([Source](https://github.com/json-everything/json-everything/blob/96e1ccfe6e233199ece276b7bc7328b1bfeac07e/src/JsonPath/JsonPath.cs#L74))
- JsonPath.TryParse always passes true as the value for PathParser.TryParse's requireGlobal parameter. ([Source](https://github.com/json-everything/json-everything/blob/96e1ccfe6e233199ece276b7bc7328b1bfeac07e/src/JsonPath/JsonPath.cs#L102))

This MR fixes the discrepancy by using the same logic in both methods.

### Links

Resolves #797 

### Checks

- [X] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
