### PR TITLE
Updated XML doc on JsonExclude

### DIFF
--- a/src/JsonSchema.Generation/Attributes/JsonExcludeAttribute.cs
+++ b/src/JsonSchema.Generation/Attributes/JsonExcludeAttribute.cs
@@ -9,7 +9,7 @@ namespace Json.Schema.Generation;
 /// <remarks>
 /// This attribute functions exactly the same as the <see cref="JsonIgnoreAttribute"/>.  It
 /// is included separately to support the case where the model should be serialized with
-/// a property but schema generation should ignore it.
+/// a property or enum member but schema generation should ignore it.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
 public sealed class JsonExcludeAttribute : JsonAttribute


### PR DESCRIPTION
### Description

In the previous PR that added the ability to skip enum members from schema generation, I didn't update the XML doc of `JsonExclude`. The generated docs would be missing this bit.

### Links

Fully resolves issue https://github.com/json-everything/json-everything/issues/795
Depends on PR https://github.com/json-everything/json-everything/pull/796

### Checks

- [ X] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
