### PR TITLE
JSON-e - $reduce & range()

### DIFF
--- a/src/JsonE.Tests/CustomFunctionTests.cs
+++ b/src/JsonE.Tests/CustomFunctionTests.cs
@@ -29,6 +29,6 @@ public class CustomFunctionTests
 
 		var result = JsonE.Evaluate(template, context);
 
-		Console.WriteLine(result);
+		Assert.That(result.IsEquivalentTo(2), Is.True);
 	}
 }

--- a/src/JsonE/EvaluationContext.cs
+++ b/src/JsonE/EvaluationContext.cs
@@ -25,6 +25,7 @@ public class EvaluationContext
 			["max"] = new MaxFunction(),
 			["min"] = new MinFunction(),
 			["number"] = new NumberFunction(),
+			["range"] = new RangeFunction(),
 			["rstrip"] = new RStripFunction(),
 			["split"] = new SplitFunction(),
 			["sqrt"] = new SqrtFunction(),

--- a/src/JsonE/Expressions/Functions/RangeFunction.cs
+++ b/src/JsonE/Expressions/Functions/RangeFunction.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+using Json.JsonE.Operators;
+using Json.More;
+
+namespace Json.JsonE.Expressions.Functions;
+
+internal class RangeFunction : FunctionDefinition
+{
+	private const string _name = "range";
+
+	internal override JsonNode? Invoke(JsonNode?[] arguments, EvaluationContext context)
+	{
+		// we store decimals, but we need to ensure they're also integer values for this function
+		if (arguments[0] is not JsonValue valStart || !valStart.TryGetValue(out decimal? start) ||
+		    (int)start.Value != start.Value)
+			throw new InterpreterException(CommonErrors.IncorrectArgType(_name));
+		if (arguments[1] is not JsonValue valEnd || !valEnd.TryGetValue(out decimal? end) ||
+		    (int)end.Value != end.Value)
+			throw new InterpreterException(CommonErrors.IncorrectArgType(_name));
+		decimal? step = null;
+		if (arguments.Length > 2 && (arguments[2] is not JsonValue valStep || !valStep.TryGetValue(out step) ||
+		                             (int)step.Value != step.Value || step.Value == 0))
+			throw new InterpreterException(CommonErrors.IncorrectArgType(_name));
+		step ??= 1;
+		var direction = Math.Sign(step.Value);
+
+		var values = new List<decimal>();
+		for (var i = start.Value * direction; i < end * direction; i += step.Value * direction)
+		{
+			values.Add(i * direction);
+		}
+
+		return values.Select(x => (JsonNode)x).ToJsonArray();
+	}
+}

--- a/src/JsonE/Expressions/Operators/NegateOperator.cs
+++ b/src/JsonE/Expressions/Operators/NegateOperator.cs
@@ -16,6 +16,6 @@ internal class NegateOperator : IUnaryOperator
 
 	public override string ToString()
 	{
-		return "!";
+		return "-";
 	}
 }

--- a/src/JsonE/Expressions/Operators/PosateOperator.cs
+++ b/src/JsonE/Expressions/Operators/PosateOperator.cs
@@ -16,6 +16,6 @@ internal class PosateOperator : IUnaryOperator
 
 	public override string ToString()
 	{
-		return "!";
+		return "+";
 	}
 }

--- a/src/JsonE/JsonE.csproj
+++ b/src/JsonE/JsonE.csproj
@@ -15,8 +15,8 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>2.1.2</Version>
-    <FileVersion>2.1.2</FileVersion>
+    <Version>2.2.0</Version>
+    <FileVersion>2.2.0</FileVersion>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>JSON-e built on the System.Text.Json namespace</Description>

--- a/src/JsonE/JsonNodeExtensions.cs
+++ b/src/JsonE/JsonNodeExtensions.cs
@@ -72,6 +72,12 @@ internal static class JsonNodeExtensions
 			throw new TemplateException(CommonErrors.UndefinedProperties(op, undefinedKeys));
 	}
 
+	public static void VerifyPropertyCount(this JsonObject obj, string op, int expectedCount)
+	{
+		if (obj.Count != expectedCount)
+			throw new TemplateException(CommonErrors.IncorrectOperatorArgCount(op, expectedCount));
+	}
+
 	public static void ValidateNotReturningFunction(this JsonNode? result)
 	{
 		var queue = new Queue<JsonNode?>();

--- a/src/JsonE/Operators/CommonErrors.cs
+++ b/src/JsonE/Operators/CommonErrors.cs
@@ -10,7 +10,7 @@ internal static class CommonErrors
 		$"{op} has undefined properties: {string.Join(" ", extraProperties.OrderBy(x => x, StringComparer.InvariantCultureIgnoreCase))}";
 
 	public static string IncorrectOperatorArgCount(string op, int expectedCount) => 
-		$"{op} must have exactly {expectedCount} properties";
+		$"{op} must have exactly {expectedCount.ToWords()} properties";
 
 	public static string IncorrectValueType(string op, string expectedType) =>
 		$"{op} value must evaluate to {expectedType}";
@@ -32,4 +32,7 @@ internal static class CommonErrors
 	public static string WrongToken(char token, params string[] expected) => $"Found: {token} token, expected one of: {string.Join(",", expected)}";
 
 	public static string EndOfInput() => "Unexpected end of input";
+
+	private static readonly List<string> _words = ["zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"]; // probably shouldn't need more than this.
+	private static string ToWords(this int count) => _words[count];
 }

--- a/src/JsonE/Operators/CommonErrors.cs
+++ b/src/JsonE/Operators/CommonErrors.cs
@@ -9,6 +9,9 @@ internal static class CommonErrors
 	public static string UndefinedProperties(string op, IEnumerable<string> extraProperties) => 
 		$"{op} has undefined properties: {string.Join(" ", extraProperties.OrderBy(x => x, StringComparer.InvariantCultureIgnoreCase))}";
 
+	public static string IncorrectOperatorArgCount(string op, int expectedCount) => 
+		$"{op} must have exactly {expectedCount} properties";
+
 	public static string IncorrectValueType(string op, string expectedType) =>
 		$"{op} value must evaluate to {expectedType}";
 

--- a/src/JsonE/Operators/FindOperator.cs
+++ b/src/JsonE/Operators/FindOperator.cs
@@ -16,16 +16,17 @@ internal class FindOperator : IOperator
 	public JsonNode? Evaluate(JsonNode? template, EvaluationContext context)
 	{
 		var obj = template!.AsObject();
+		obj.VerifyPropertyCount(Name, 2);
 		obj.VerifyNoUndefinedProperties(Name, _eachForm);
 	
 		var value = JsonE.Evaluate(obj[Name], context);
 
 		var eachEntry = obj.FirstOrDefault(x => x.Key != Name);
 		if (eachEntry.Value is not JsonValue eachValue)
-			throw new TemplateException($"each can evaluate string expressions only");
+			throw new TemplateException("each can evaluate string expressions only");
 		var eachTemplate = eachValue.GetString();
 		if (eachTemplate is null)
-			throw new TemplateException($"each can evaluate string expressions only");
+			throw new TemplateException("each can evaluate string expressions only");
 
 		if (value is not JsonArray array)
 			throw new TemplateException(CommonErrors.IncorrectValueType(Name, "an array"));

--- a/src/JsonE/Operators/MapOperator.cs
+++ b/src/JsonE/Operators/MapOperator.cs
@@ -13,7 +13,7 @@ internal class MapOperator : IOperator
 	public JsonNode? Evaluate(JsonNode? template, EvaluationContext context)
 	{
 		var obj = template!.AsObject();
-		obj.VerifyPropertyCount(Name, 3);
+		obj.VerifyPropertyCount(Name, 2);
 		obj.VerifyNoUndefinedProperties(Name, _byForm);
 	
 		var value = JsonE.Evaluate(obj[Name], context);

--- a/src/JsonE/Operators/MapOperator.cs
+++ b/src/JsonE/Operators/MapOperator.cs
@@ -13,6 +13,7 @@ internal class MapOperator : IOperator
 	public JsonNode? Evaluate(JsonNode? template, EvaluationContext context)
 	{
 		var obj = template!.AsObject();
+		obj.VerifyPropertyCount(Name, 3);
 		obj.VerifyNoUndefinedProperties(Name, _byForm);
 	
 		var value = JsonE.Evaluate(obj[Name], context);

--- a/src/JsonE/Operators/OperatorRepository.cs
+++ b/src/JsonE/Operators/OperatorRepository.cs
@@ -21,6 +21,7 @@ internal static class OperatorRepository
 		[MatchOperator.Name] = new MatchOperator(),
 		[MergeOperator.Name] = new MergeOperator(),
 		[MergeDeepOperator.Name] = new MergeDeepOperator(),
+		[ReduceOperator.Name] = new ReduceOperator(),
 		[ReverseOperator.Name] = new ReverseOperator(),
 		[SortOperator.Name] = new SortOperator(),
 		[SwitchOperator.Name] = new SwitchOperator(),

--- a/src/JsonE/Operators/ReduceOperator.cs
+++ b/src/JsonE/Operators/ReduceOperator.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+
+namespace Json.JsonE.Operators;
+
+internal class ReduceOperator : IOperator
+{ 
+	private static readonly Regex _byForm = new(@"^each\(\s*(?<var1>[a-zA-Z_][a-zA-Z0-9_]*)\s*(,\s*(?<var2>[a-zA-Z_][a-zA-Z0-9_]*))?(,\s*(?<var3>[a-zA-Z_][a-zA-Z0-9_]*))?\s*\)");
+
+	public const string Name = "$reduce";
+
+	public JsonNode? Evaluate(JsonNode? template, EvaluationContext context)
+	{
+		var obj = template!.AsObject();
+		obj.VerifyNoUndefinedProperties(Name, "initial", _byForm);
+
+		var value = JsonE.Evaluate(obj[Name], context);
+		if (value is not JsonArray items)
+			throw new TemplateException(CommonErrors.IncorrectValueType(Name, "an array"));
+
+		var initial = JsonE.Evaluate(obj["initial"], context);
+
+		var eachEntry = obj.FirstOrDefault(x => x.Key is not (Name or "initial"));
+		var eachTemplate = eachEntry.Value;
+
+		return EvaluateAsArray(items, initial, eachEntry.Key, eachTemplate, context);
+	}
+
+	private static JsonNode? EvaluateAsArray(JsonArray value, JsonNode? initial, string each, JsonNode? template, EvaluationContext context)
+	{
+		var match = _byForm.Match(each);
+		var accVar = match.Groups["var1"].Value;
+		var itemVar = match.Groups["var2"].Value;
+		var indexVar = match.Groups["var3"].Success ? match.Groups["var3"].Value : null;
+
+		var itemContext = new JsonObject
+		{
+			[accVar] = initial?.Clone(),
+			[itemVar] = null
+		};
+		if (indexVar != null)
+			itemContext[indexVar] = 0;
+
+		context.Push(itemContext);
+
+		for (var i = 0; i < value.Count; i++)
+		{
+			itemContext[itemVar] = value[i].Clone();
+			if (indexVar != null)
+				itemContext[indexVar] = i;
+
+			var localResult = JsonE.Evaluate(template, context);
+			if (!ReferenceEquals(localResult, JsonE.DeleteMarker))
+				itemContext[accVar] = localResult.Clone();
+		}
+
+		context.Pop();
+		return itemContext[accVar];
+	}
+}

--- a/src/JsonE/Operators/ReduceOperator.cs
+++ b/src/JsonE/Operators/ReduceOperator.cs
@@ -14,6 +14,7 @@ internal class ReduceOperator : IOperator
 	public JsonNode? Evaluate(JsonNode? template, EvaluationContext context)
 	{
 		var obj = template!.AsObject();
+		obj.VerifyPropertyCount(Name, 3);
 		obj.VerifyNoUndefinedProperties(Name, "initial", _byForm);
 
 		var value = JsonE.Evaluate(obj[Name], context);

--- a/tools/ApiDocsGenerator/release-notes/rn-json-e.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-e.md
@@ -4,6 +4,10 @@ title: JsonE.Net
 icon: fas fa-tag
 order: "09.12"
 ---
+# [2.2.0](https://github.com/gregsdennis/json-everything/pull/805) {#release-e-2.2.0}
+
+Adds the newly introduced `$reduce` operator and `range()` functions.
+
 # [2.1.2](https://github.com/gregsdennis/json-everything/commits/6a426380c5597312945d4e743d44c3f530f7f18e) {#release-e-2.1.2}
 
 `InterpreterException` now derives from `JsonEException` like all of the other exceptions.


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

<!--
Please add a short description of the changes.  Be sure to include:
  - whether this affects the public API surface
  - whether the changes cause breaks in either developer experience or behavior
-->

Adds the new `$reduce` operator and `range()` function.

### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
Resolves #804
Relates to https://github.com/json-e/json-e/pull/531 & https://github.com/json-e/json-e/pull/534

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
