### PR TITLE
add support for c# required keyword in schema gen

### DIFF
--- a/src/JsonPath.Tests/ParsingTests.cs
+++ b/src/JsonPath.Tests/ParsingTests.cs
@@ -143,14 +143,14 @@ public class ParsingTests
 	[TestCaseSource(nameof(SuccessCases))]
 	public void ParseRelativeStarts(string path)
 	{
-		path = $"@{path[1..]}"; // Turn the absolute path into a relative path
-		Assert.DoesNotThrow(() => JsonPath.Parse(path, new PathParsingOptions(){AllowRelativePathStart = true}));
+		path = $"@{path.Substring(1)}"; // Turn the absolute path into a relative path
+		Assert.DoesNotThrow(() => JsonPath.Parse(path, new PathParsingOptions{AllowRelativePathStart = true}));
 	}
 
 	[TestCaseSource(nameof(SuccessCases))]
 	public void TryParseRelativeStarts(string path)
 	{
-		path = $"@{path[1..]}"; // Turn the absolute path into a relative path
-		Assert.That(JsonPath.TryParse(path, out _, new PathParsingOptions(){AllowRelativePathStart = true}));
+		path = $"@{path.Substring(1)}"; // Turn the absolute path into a relative path
+		Assert.That(JsonPath.TryParse(path, out _, new PathParsingOptions{AllowRelativePathStart = true}));
 	}
 }

--- a/src/JsonSchema.Generation.Tests/ClientTests.cs
+++ b/src/JsonSchema.Generation.Tests/ClientTests.cs
@@ -469,4 +469,61 @@ public class ClientTests
 
 		Assert.That(schemaJson.IsEquivalentTo(expected), Is.True);
 	}
+
+#if NET8_0_OR_GREATER
+	private const string ExternalSchemaUri = "https://test.json-everything.net/has-external-schema";
+	private const string GeneratedSchemaUri = "https://test.json-everything.net/uses-external-schema";
+
+	[Id(ExternalSchemaUri)]
+	internal class HasExternalSchemaUsingIdAttribute
+	{
+		public int Value { get; set; }
+	}
+
+	[Id(GeneratedSchemaUri)]
+	internal class ShouldRefToExternalSchemaUsingIdAttributeWithRequiredKeyword
+	{
+		// it is this required keyword that prevents the $ref
+		public required HasExternalSchemaUsingIdAttribute ShouldRef { get; set; }
+	}
+
+	[Id(GeneratedSchemaUri)]
+	internal class ShouldRefToExternalSchemaUsingIdAttributeWithRequiredAttribute
+	{
+		[Required]
+		public HasExternalSchemaUsingIdAttribute ShouldRef { get; set; }
+	}
+
+	[Test]
+	public void Issue815_UsingCSharpRequiredKeyword()
+	{
+		JsonSchema expected = new JsonSchemaBuilder()
+			.Id(GeneratedSchemaUri)
+			.Type(SchemaValueType.Object)
+			.Properties(
+				("ShouldRef", new JsonSchemaBuilder().Ref(ExternalSchemaUri))
+			)
+			.Required("ShouldRef");
+
+		JsonSchema actual = new JsonSchemaBuilder().FromType<ShouldRefToExternalSchemaUsingIdAttributeWithRequiredKeyword>();
+
+		AssertEqual(expected, actual);
+	}
+
+	[Test]
+	public void Issue815_UsingRequiredAttribute()
+	{
+		JsonSchema expected = new JsonSchemaBuilder()
+			.Id(GeneratedSchemaUri)
+			.Type(SchemaValueType.Object)
+			.Properties(
+				("ShouldRef", new JsonSchemaBuilder().Ref(ExternalSchemaUri))
+			)
+			.Required("ShouldRef");
+
+		JsonSchema actual = new JsonSchemaBuilder().FromType<ShouldRefToExternalSchemaUsingIdAttributeWithRequiredKeyword>();
+
+		AssertEqual(expected, actual);
+	}
+#endif
 }

--- a/src/JsonSchema.Generation/Generators/ObjectSchemaGenerator.cs
+++ b/src/JsonSchema.Generation/Generators/ObjectSchemaGenerator.cs
@@ -103,7 +103,11 @@ internal class ObjectSchemaGenerator : ISchemaGenerator
 			else
 				props.Add(name, memberContext);
 
-			if (unconditionalAttributes.OfType<RequiredAttribute>().Any())
+			if (unconditionalAttributes.OfType<RequiredAttribute>().Any()
+#if NET7_0_OR_GREATER
+				|| unconditionalAttributes.OfType<System.Runtime.CompilerServices.RequiredMemberAttribute>().Any()
+#endif
+				)
 				required.Add(name);
 
 			foreach (var conditionalRequiredAttribute in localConditionalAttributes.OfType<RequiredAttribute>())

--- a/src/JsonSchema.Generation/JsonSchema.Generation.csproj
+++ b/src/JsonSchema.Generation/JsonSchema.Generation.csproj
@@ -15,8 +15,8 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>4.6.0</Version>
-    <FileVersion>4.6.0</FileVersion>
+    <Version>4.6.1</Version>
+    <FileVersion>4.6.1</FileVersion>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>Extends JsonSchema.Net to provide schema generation functionality</Description>

--- a/src/JsonSchema.Generation/SchemaGenerationContextCache.cs
+++ b/src/JsonSchema.Generation/SchemaGenerationContextCache.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Json.Schema.Generation.Intents;
 
 namespace Json.Schema.Generation;
@@ -45,12 +46,13 @@ public static class SchemaGenerationContextCache
 
 	private static SchemaGenerationContextBase Get(Type type, List<Attribute>? memberAttributes, bool isRoot)
 	{
-		var hash = CalculateHash(type, memberAttributes?.WhereHandled());
+		var handledAttributes = memberAttributes?.WhereHandled().ToList();
+		var hash = CalculateHash(type, handledAttributes);
 		if (!Cache.TryGetValue(hash, out var context))
 		{
-			if (memberAttributes != null && memberAttributes.Count != 0)
+			if (handledAttributes != null && handledAttributes.Count != 0)
 			{
-				var memberContext = new MemberGenerationContext(type, memberAttributes);
+				var memberContext = new MemberGenerationContext(type, memberAttributes!);
 				context = memberContext;
 				Cache[hash] = memberContext;
 				memberContext.BasedOn = Get(type);

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema-generation.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema-generation.md
@@ -4,7 +4,11 @@ title: JsonSchema.Net.Generation
 icon: fas fa-tag
 order: "09.05"
 ---
-# [2.3.0](https://github.com/gregsdennis/json-everything/pull/822) {#release-e-2.3.0}
+# [4.6.1](https://github.com/gregsdennis/json-everything/pull/817) {#release-schemagen-4.6.1}
+
+[#815](https://github.com/gregsdennis/json-everything/issues/816) - Added support for C# `required` keyword (.Net 7+).  The keyword will now generate a JSON Schema `required` keyword for the appropriate properties.  Thanks to [@epenelle-genetec](https://github.com/epenelle-genetec) for finding and suggesting the solution.
+
+# [4.6.0](https://github.com/gregsdennis/json-everything/pull/822) {#release-schemagen-4.6.0}
 
 Add .Net 9.0 support.
 


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

<!--
Please add a short description of the changes.  Be sure to include:
  - whether this affects the public API surface
  - whether the changes cause breaks in either developer experience or behavior
-->

Adds support for C# `required` keyword in scheam generation.  (.Net 7+)

### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
Resolves #815     <!-- Use if these changes completely resolve the issue -->

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
