### PR TITLE
fix: make copy with '-' as target working

### DIFF
--- a/src/JsonPatch.Tests/GithubTests.cs
+++ b/src/JsonPatch.Tests/GithubTests.cs
@@ -211,7 +211,7 @@ public class GithubTests
 	}
 
 	[Test]
-	public void MoveShouldMoveItemAround()
+	public void Issue825_MoveShouldMoveItemToTheEndOfArray()
 	{
 		var jsonModel = new JsonObject
 		{
@@ -226,11 +226,36 @@ public class GithubTests
 		var result = doc.Apply(jsonModel);
 
 		Assert.That(result.Error, Is.Null);
-		Assert.That(result.Result!["Items"]!.AsArray()[^1].IsEquivalentTo(3));
+
+		var jsonArray = result.Result!["Items"]!.AsArray();
+		Assert.That(jsonArray, Has.Count.EqualTo(5));
+		Assert.That(jsonArray[^1].IsEquivalentTo(3));
 	}
 
 	[Test]
-	public void CopyShouldCopyValuesToTarget()
+	public void Issue825_CopyShouldCopyItemToEndOfArray()
+	{
+		var jsonModel = new JsonObject
+		{
+			["Items"] = new JsonArray(1, 2, 3, 4, 5)
+		};
+
+		var doc = new JsonPatch(
+			PatchOperation.Copy(
+				JsonPointer.Parse("/Items/2"),
+				JsonPointer.Parse("/Items/-")));
+
+		var result = doc.Apply(jsonModel);
+
+		Assert.That(result.Error, Is.Null);
+
+		var jsonArray = result.Result!["Items"]!.AsArray();
+		Assert.That(jsonArray, Has.Count.EqualTo(6));
+		Assert.That(jsonArray[^1].IsEquivalentTo(3));
+	}
+
+	[Test]
+	public void Issue826_CopyShouldCopyValuesToTarget()
 	{
 		var jsonModel = new JsonObject
 		{

--- a/src/JsonPatch/CopyOperationHandler.cs
+++ b/src/JsonPatch/CopyOperationHandler.cs
@@ -41,7 +41,7 @@ internal class CopyOperationHandler : IPatchOperationHandler
 
 		if (target is JsonArray arrTarget)
 		{
-			var index = lastPathSegment.Length == 0 && lastPathSegment[0] == '-'
+			var index = lastPathSegment.Length != 0 && lastPathSegment[0] == '-'
 				? arrTarget.Count
 				: int.TryParse(lastPathSegment, out var i)
 					? i

--- a/src/JsonPatch/JsonPatch.csproj
+++ b/src/JsonPatch/JsonPatch.csproj
@@ -15,8 +15,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>JsonPatch.Net</PackageId>
-    <Version>3.2.1</Version>
-    <FileVersion>3.2.1</FileVersion>
+    <Version>3.2.2</Version>
+    <FileVersion>3.2.2</FileVersion>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>JSON Patch built on the System.Text.Json namespace</Description>

--- a/tools/ApiDocsGenerator/release-notes/rn-json-patch.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-patch.md
@@ -4,6 +4,10 @@ title: JsonPatch.Net
 icon: fas fa-tag
 order: "09.09"
 ---
+# [3.2.2](https://github.com/gregsdennis/json-everything/pull/827) {#release-patch-3.2.2}
+
+- [#825](https://github.com/gregsdennis/json-everything/issues/825) - Copy not working when `to` pointer ends with `-`.  (Cannot copy to end of array.)
+
 # [3.2.1](https://github.com/gregsdennis/json-everything/pull/827) {#release-patch-3.2.1}
 
 - [#825](https://github.com/gregsdennis/json-everything/issues/825) - Move not working when `to` pointer ends with `-`.  (Cannot move to end of array.)


### PR DESCRIPTION
### Description

Missing fix for issue #825 

It was not possible to copy an item to the end of an array.

### Links

Relates to  #825   

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
