### PR TITLE
fix: make end of array via '-' accessible

### DIFF
--- a/src/JsonPatch.Tests/GithubTests.cs
+++ b/src/JsonPatch.Tests/GithubTests.cs
@@ -255,6 +255,47 @@ public class GithubTests
 	}
 
 	[Test]
+	public void Issue825_RemoveShouldRemoveItemAtEndOfArray()
+	{
+		var jsonModel = new JsonObject
+		{
+			["Items"] = new JsonArray(1, 2, 3, 4, 5)
+		};
+
+		var doc = new JsonPatch(PatchOperation.Remove(JsonPointer.Parse("/Items/-")));
+
+		var result = doc.Apply(jsonModel);
+
+		Assert.That(result.Error, Is.Null);
+
+		var jsonArray = result.Result!["Items"]!.AsArray();
+		Assert.That(jsonArray, Has.Count.EqualTo(4));
+		Assert.That(jsonArray[^1].IsEquivalentTo(4));
+	}
+
+	[TestCase("/Items/-")]
+	[TestCase("/Items/4")]
+	public void Issue825_ReplaceShouldReplaceItemToEndOfArray(string path)
+	{
+		var jsonModel = new JsonObject
+		{
+			["Items"] = new JsonArray(1, 2, 3, 4, 5)
+		};
+
+		var doc = new JsonPatch(PatchOperation.Replace(
+			JsonPointer.Parse(path),
+			JsonNode.Parse("6")));
+
+		var result = doc.Apply(jsonModel);
+
+		Assert.That(result.Error, Is.Null);
+
+		var jsonArray = result.Result!["Items"]!.AsArray();
+		Assert.That(jsonArray, Has.Count.EqualTo(5));
+		Assert.That(jsonArray[^1].IsEquivalentTo(6));
+	}
+
+	[Test]
 	public void Issue826_CopyShouldCopyValuesToTarget()
 	{
 		var jsonModel = new JsonObject

--- a/src/JsonPatch/JsonPatch.csproj
+++ b/src/JsonPatch/JsonPatch.csproj
@@ -15,8 +15,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>JsonPatch.Net</PackageId>
-    <Version>3.2.2</Version>
-    <FileVersion>3.2.2</FileVersion>
+    <Version>3.2.3</Version>
+    <FileVersion>3.2.3</FileVersion>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>JSON Patch built on the System.Text.Json namespace</Description>

--- a/src/JsonPatch/RemoveOperationHandler.cs
+++ b/src/JsonPatch/RemoveOperationHandler.cs
@@ -29,7 +29,7 @@ internal class RemoveOperationHandler : IPatchOperationHandler
 			objSource.Remove(lastPathSegment);
 		else if (source is JsonArray arrSource)
 		{
-			var index = lastPathSegment.Length == 0 && lastPathSegment[0] == '-'
+			var index = lastPathSegment.Length != 0 && lastPathSegment[0] == '-'
 				? arrSource.Count - 1
 				: int.TryParse(lastPathSegment, out var i)
 					? i

--- a/src/JsonPatch/ReplaceOperationHandler.cs
+++ b/src/JsonPatch/ReplaceOperationHandler.cs
@@ -33,8 +33,8 @@ internal class ReplaceOperationHandler : IPatchOperationHandler
 		if (target is JsonArray arrTarget)
 		{
 			int index;
-			if (lastPathSegment.Length == 0 && lastPathSegment[0] == '-')
-				index = arrTarget.Count;
+			if (lastPathSegment.Length != 0 && lastPathSegment[0] == '-')
+				index = arrTarget.Count - 1;
 			else if (!int.TryParse(lastPathSegment, out index))
 			{
 				context.Message = $"Target path `{operation.Path}` could not be reached.";
@@ -42,8 +42,6 @@ internal class ReplaceOperationHandler : IPatchOperationHandler
 			}
 			if (0 <= index && index < arrTarget.Count)
 				arrTarget[index] = operation.Value?.DeepClone();
-			else if (index == arrTarget.Count)
-				arrTarget.Add(operation.Value?.DeepClone());
 			else
 				context.Message = "Path indicates an index greater than the bounds of the array";
 		}

--- a/tools/ApiDocsGenerator/release-notes/rn-json-patch.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-patch.md
@@ -4,7 +4,11 @@ title: JsonPatch.Net
 icon: fas fa-tag
 order: "09.09"
 ---
-# [3.2.2](https://github.com/gregsdennis/json-everything/pull/827) {#release-patch-3.2.2}
+# [3.2.3](https://github.com/gregsdennis/json-everything/pull/829) {#release-patch-3.2.3}
+
+- [#825](https://github.com/gregsdennis/json-everything/issues/825) - Remove and replace not working when `path` pointer ends with `-`.  (Cannot access end of array.)
+
+# [3.2.2](https://github.com/gregsdennis/json-everything/pull/828) {#release-patch-3.2.2}
 
 - [#825](https://github.com/gregsdennis/json-everything/issues/825) - Copy not working when `to` pointer ends with `-`.  (Cannot copy to end of array.)
 


### PR DESCRIPTION
### Description

Unfortunately, I missed two more places with the same issue...

This PR makes the following syntax possible for the patch operations remove and replace: `/Items/-`
It will then remove or replace the last element in the array.

---

I have also removed the logic in the replace operation to add new elements to the array.
Until now the following was possible (pseudo-code):

```
array = [1, 2, 3]

array = array.Replace("/Items/3", 4)

array --> [1, 2, 3, 4]
```

According to the [JsonPatch specification](https://datatracker.ietf.org/doc/html/rfc6902#section-4.3) for the replacement operation: `The target location MUST exist for the operation to be successful.`

It should therefore not be possible to reference a not existing index of the array.


### Links

#825 

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
