### PR TITLE
Add Korean Localization

### DIFF
--- a/src/JsonSchema/Localization/Resources.ko.resx
+++ b/src/JsonSchema/Localization/Resources.ko.resx
@@ -1,0 +1,204 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Error_Const" xml:space="preserve">
+    <value>[[value]] 예상됨</value>
+  </data>
+  <data name="Error_ContainsTooFew" xml:space="preserve">
+    <value>값은 최소한 [[minimum]]개의 일치 항목을 포함해야 합니다</value>
+  </data>
+  <data name="Error_ContainsTooMany" xml:space="preserve">
+    <value>값은 [[maximum]]개보다 많은 일치 항목을 포함하면 안됩니다</value>
+  </data>
+  <data name="Error_DependentRequired" xml:space="preserve">
+    <value>일부 필수 속성 종속성이 누락되었습니다: [[missing]]</value>
+  </data>
+  <data name="Error_DependentSchemas" xml:space="preserve">
+    <value>일부 속성이 종속 스키마에 실패했습니다: [[failed]]</value>
+  </data>
+  <data name="Error_Enum" xml:space="preserve">
+    <value>값은 열거형에 지정된 값 중 하나와 일치해야 합니다</value>
+  </data>
+  <data name="Error_ExclusiveMaximum" xml:space="preserve">
+    <value>[[received]]은(는) [[limit]]보다 작아야 합니다</value>
+  </data>
+  <data name="Error_ExclusiveMinimum" xml:space="preserve">
+    <value>[[received]]은(는) [[limit]]보다 커야 합니다</value>
+  </data>
+  <data name="Error_FalseSchema" xml:space="preserve">
+    <value>모든 값이 잘못된 스키마에 대해 실패했습니다</value>
+  </data>
+  <data name="Error_Format" xml:space="preserve">
+    <value>값이 [[format]] 형식에 맞지 않습니다</value>
+  </data>
+  <data name="Error_FormatWithDetail" xml:space="preserve">
+    <value>값이 [[format]] 형식에 맞지 않습니다: [[detail]]</value>
+  </data>
+  <data name="Error_Maximum" xml:space="preserve">
+    <value>[[received]]은(는) 최대 [[limit]]이어야 합니다</value>
+  </data>
+  <data name="Error_MaxItems" xml:space="preserve">
+    <value>값은 최대 [[limit]]개의 항목을 가져야 합니다</value>
+  </data>
+  <data name="Error_MaxLength" xml:space="preserve">
+    <value>값은 최대 [[limit]]자여야 합니다</value>
+  </data>
+  <data name="Error_MaxProperties" xml:space="preserve">
+    <value>값은 최대 [[limit]]개의 속성을 가져야 합니다</value>
+  </data>
+  <data name="Error_MetaSchemaValidation" xml:space="preserve">
+    <value>현재 스키마를 메타 스키마 [[uri]]에 대해 검증할 수 없습니다</value>
+  </data>
+  <data name="Error_Minimum" xml:space="preserve">
+    <value>[[received]]은(는) 최소 [[limit]]이어야 합니다</value>
+  </data>
+  <data name="Error_MinItems" xml:space="preserve">
+    <value>값은 최소 [[limit]]개의 항목을 가져야 합니다</value>
+  </data>
+  <data name="Error_MinLength" xml:space="preserve">
+    <value>값은 최소 [[limit]]자여야 합니다</value>
+  </data>
+  <data name="Error_MinProperties" xml:space="preserve">
+    <value>값은 최소 [[limit]]개의 속성을 가져야 합니다</value>
+  </data>
+  <data name="Error_MultipleOf" xml:space="preserve">
+    <value>[[received]]은(는) [[divisor]]의 배수여야 합니다</value>
+  </data>
+  <data name="Error_OneOf" xml:space="preserve">
+    <value>일치하는 하위 스키마가 1개 예상되었지만 [[count]]개가 발견되었습니다</value>
+  </data>
+  <data name="Error_Pattern" xml:space="preserve">
+    <value>문자열 값이 가리키는 정규 표현식과 일치하지 않습니다</value>
+  </data>
+  <data name="Error_Required" xml:space="preserve">
+    <value>필수 속성 [[missing]]이(가) 없습니다</value>
+  </data>
+  <data name="Error_Type" xml:space="preserve">
+    <value>값이 [[received]]이지만 [[expected]]여야 합니다</value>
+  </data>
+  <data name="Error_UniqueItems" xml:space="preserve">
+    <value>다음 색인 쌍에서 중복이 발견되었습니다: [[duplicates]]</value>
+  </data>
+  <data name="Error_UnknownFormat" xml:space="preserve">
+    <value>알 수 없는 형식 [[format]]을 검증할 수 없습니다</value>
+  </data>
+  <data name="Error_UnknownVocabularies" xml:space="preserve">
+    <value>유효성 검사기는 다음 필수 어휘를 모릅니다: [[vocabs]]</value>
+  </data>
+</root>

--- a/src/JsonSchema/nuspec/JsonSchema.Net.ko.nuspec
+++ b/src/JsonSchema/nuspec/JsonSchema.Net.ko.nuspec
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata minClientVersion="2.12">
+    <id>JsonSchema.Net.ko</id>
+    <version>1.0.0.1</version>
+    <title>JsonSchema.Net Locale (ko)</title>
+    <authors>Greg Dennis</authors>
+    <projectUrl>https://github.com/json-everything/json-everything</projectUrl>
+    <icon>json-logo-256.png</icon>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>JsonSchema.Net Locale Korean (ko)</description>
+    <releaseNotes>Release notes can be found at https://json-everything.net/json-schema</releaseNotes>
+    <readme>README.ko.md</readme>
+    <license type="expression">MIT</license>
+    <repository type="git" url="https://github.com/json-everything/json-everything" />
+    <language>ko</language>
+    <dependencies>
+      <dependency id="JsonSchema.Net" version="6.0.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="..\bin\Release\netstandard2.0\ru\JsonSchema.Net.resources.dll" target="lib\netstandard2.0\ko" />
+    <file src="..\bin\Release\netstandard2.0\json-logo-256.png" target="json-logo-256.png" />
+    <file src="README.ko.md" target="\" />
+  </files>
+</package>

--- a/src/JsonSchema/nuspec/README.ko.md
+++ b/src/JsonSchema/nuspec/README.ko.md
@@ -1,0 +1,26 @@
+## 요약
+
+JsonSchema.Net.ko는 [JsonSchema.Net](https://www.nuget.org/packages/JsonSchema.Net)을 확장하여 한국어 오류 메시지를 제공합니다.
+
+## 링크
+
+- [문서](https://docs.json-everything.net/pointer/basics/)
+- [API 참조](https://docs.json-everything.net/api/JsonPointer.Net/JsonPointer/)
+- [릴리스 노트](https://docs.json-everything.net/rn-json-pointer/)
+
+## 사용법
+
+문화권을 전역적으로 설정합니다.
+
+```c#
+ErrorMessages.Culture = CultureInfo.GetCultureInfo("ko");
+```
+
+또는 옵션에서:
+
+```c#
+var options = new EvaluationOptions
+{
+    Culture = CultureInfo.GetCultureInfo("ko")
+}
+```


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

This PR adds a Korean translation of JsonSchema.Net to make it easier for Korean speakers to understand error messages.

### Links

Nothing

### Checks

- [X] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
