### PR TITLE
add dependency check for jsonschema.net

### DIFF
--- a/src/JsonSchema.Tests/DependencyChecks.cs
+++ b/src/JsonSchema.Tests/DependencyChecks.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Json.Pointer;
+using NUnit.Framework;
+
+namespace Json.Schema.Tests;
+
+public class DependencyChecks
+{
+	// already copied as part of library build
+	private const string NuspecFile = "nuspec/JsonSchema.Net.nuspec";
+
+	private static readonly string[] focusedAssemblies =
+	[
+		"Json.More",
+		"JsonPointer.Net"
+	];
+
+	[Test]
+	public void VerifyDependencyVersions()
+	{
+		_ = JsonPointer.Create("load"); // need to load the assembly when the other tests aren't run
+	
+		var nuspecLines = File.ReadAllLines(NuspecFile);
+		var nugetDependencies = nuspecLines
+			.Select(x => Regex.Match(x, @"id=""(?<lib>.*)"" version=""(?<version>\d*\.\d*\.\d*(\.\d*)?(-.*)?)"""))
+			.Where(x1 => x1.Success)
+			.ToDictionary(GetLibName, GetVersion);
+
+		var library = typeof(JsonSchema).Assembly;
+		var domain = AppDomain.CurrentDomain.GetAssemblies().OrderBy(x => x.FullName);
+		var libDependencies = library.GetReferencedAssemblies()
+			.Where(x => focusedAssemblies.Contains(x.Name))
+			.ToDictionary(x => x.Name, x => domain.First(a => a.GetName().Name == x.Name));
+
+		foreach (var (nugetDependency, nugetVersion) in nugetDependencies)
+		{
+			var libDependency = libDependencies[nugetDependency];
+			var libVersion = ((AssemblyInformationalVersionAttribute?)libDependency
+				.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute))
+				.SingleOrDefault())?.InformationalVersion;
+
+			Assert.That(libVersion, Does.StartWith(nugetVersion));
+		}
+	}
+
+	private string? GetLibName(Match match)
+	{
+		var pkgName = match.Groups["lib"].Value;
+		return focusedAssemblies.FirstOrDefault(pkgName.StartsWith);
+	}
+
+	private string GetVersion(Match match) => match.Groups["version"].Value;
+}

--- a/src/JsonSchema/JsonSchema.csproj
+++ b/src/JsonSchema/JsonSchema.csproj
@@ -17,8 +17,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>JsonSchema.Net</PackageId>
-    <Version>7.3.0</Version>
-    <FileVersion>7.3.0</FileVersion>
+    <Version>7.3.1</Version>
+    <FileVersion>7.3.1</FileVersion>
     <AssemblyVersion>7.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>JSON Schema built on the System.Text.Json namespace</Description>

--- a/src/JsonSchema/nuspec/JsonSchema.Net.nuspec
+++ b/src/JsonSchema/nuspec/JsonSchema.Net.nuspec
@@ -13,7 +13,7 @@
     <tags>json-schema validation schema json</tags>
     <repository type="git" url="https://github.com/json-everything/json-everything" />
     <dependencies>
-      <dependency id="JsonPointer.Net" version="5.0.0" exclude="Build,Analyzers" />
+      <dependency id="JsonPointer.Net" version="5.1.0" exclude="Build,Analyzers" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

<!--
Please add a short description of the changes.  Be sure to include:
  - whether this affects the public API surface
  - whether the changes cause breaks in either developer experience or behavior
-->
Adds a dependency check that will fail when nuspec file for `JsonSchema.Net` isn't aligned with latest lib versions.

### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
Resolves #844

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
