### PR TITLE
Properly dispose of rented memory in JsonPointer.ToString()

### DIFF
--- a/src/JsonPointer.Tests/JsonPointerParseTests.cs
+++ b/src/JsonPointer.Tests/JsonPointerParseTests.cs
@@ -130,6 +130,19 @@ public class JsonPointerParseTests
 		Assert.That(actual, Is.EqualTo(expected));
 	}
 
+	[Test]
+	public void TrailingSlash()
+	{
+		var result = JsonPointer.TryParse("/foo/", out var pointer);
+
+		Assert.That(result, Is.True);
+		Assert.That(pointer, Is.Not.Null);
+		Assert.That(pointer.Count, Is.EqualTo(2));
+
+		Assert.That(pointer.First(), Is.EqualTo("foo"));
+		Assert.That(pointer.Last(), Is.EqualTo(""));
+	}
+
 	[TestCaseSource(nameof(SpecificationExamples))]
 	public void CreateThenToString(string pointerString, string[] segments)
 	{

--- a/src/JsonPointer.Tests/JsonPointerTests.cs
+++ b/src/JsonPointer.Tests/JsonPointerTests.cs
@@ -113,4 +113,22 @@ public class JsonPointerTests
 
 		Assert.That(pointer.ToString(), Is.EqualTo("/string/1/foo"));
 	}
+
+	[Test]
+	public void ToString_WithEncodedCharacters()
+	{
+		var p = JsonPointer.Create("some", "pointer", "with~tilde");
+
+		var result = p.ToString();
+		Assert.That(result, Is.EqualTo("/some/pointer/with~0tilde"));
+	}
+
+	[Test]
+	public void ToString_EncodedCharactersOnly()
+	{
+		var p = JsonPointer.Create("~~~~~~~~~", "/////////", "~~~~~~~~~", "/////////");
+
+		var result = p.ToString();
+		Assert.That(result, Is.EqualTo("/~0~0~0~0~0~0~0~0~0/~1~1~1~1~1~1~1~1~1/~0~0~0~0~0~0~0~0~0/~1~1~1~1~1~1~1~1~1"));
+	}
 }

--- a/src/JsonPointer/JsonPointer.cs
+++ b/src/JsonPointer/JsonPointer.cs
@@ -106,7 +106,7 @@ public class JsonPointer : IEquatable<JsonPointer>, IReadOnlyList<string>
 		var sourceSpan = source.AsSpan();
 		using var segmentMemory = MemoryPool<string>.Shared.Rent();
 		var segments = segmentMemory.Memory.Span;
-		using var builderMemory = MemoryPool<char>.Shared.Rent();
+		using var builderMemory = MemoryPool<char>.Shared.Rent(source.Length);
 		var builder = builderMemory.Memory.Span;
 		while (sourceIndex < source.Length)
 		{
@@ -167,7 +167,7 @@ public class JsonPointer : IEquatable<JsonPointer>, IReadOnlyList<string>
 		var sourceSpan = source.AsSpan();
 		using var segmentMemory = MemoryPool<string>.Shared.Rent();
 		var segments = segmentMemory.Memory.Span;
-		using var builderMemory = MemoryPool<char>.Shared.Rent();
+		using var builderMemory = MemoryPool<char>.Shared.Rent(source.Length);
 		var builder = builderMemory.Memory.Span;
 		while (sourceIndex < source.Length)
 		{

--- a/src/JsonPointer/JsonPointer.cs
+++ b/src/JsonPointer/JsonPointer.cs
@@ -536,7 +536,7 @@ public class JsonPointer : IEquatable<JsonPointer>, IReadOnlyList<string>
 		{
 			final[length] = '/';
 			length++;
-			using var localOwner = MemoryPool<char>.Shared.Rent(segment.Length);
+			using var localOwner = MemoryPool<char>.Shared.Rent(segment.Length * 2);
 			var local = localOwner.Memory.Span;
 			var localLength = segment.AsSpan().Encode(local);
 			local[..localLength].CopyTo(final[length..]);

--- a/src/JsonPointer/JsonPointer.cs
+++ b/src/JsonPointer/JsonPointer.cs
@@ -536,7 +536,7 @@ public class JsonPointer : IEquatable<JsonPointer>, IReadOnlyList<string>
 		{
 			final[length] = '/';
 			length++;
-			var localOwner = MemoryPool<char>.Shared.Rent();
+			using var localOwner = MemoryPool<char>.Shared.Rent(segment.Length);
 			var local = localOwner.Memory.Span;
 			var localLength = segment.AsSpan().Encode(local);
 			local[..localLength].CopyTo(final[length..]);

--- a/src/JsonPointer/JsonPointer.cs
+++ b/src/JsonPointer/JsonPointer.cs
@@ -138,14 +138,14 @@ public class JsonPointer : IEquatable<JsonPointer>, IReadOnlyList<string>
 		var segments = new string[segmentCount];
 		var segmentIndex = 0;
 
+		source = source[1..];
 		foreach (var segmentRange in source.Split('/'))
-		{
-			if (segmentRange.Start.Value != segmentRange.End.Value)
-				if (!TryDecodeSegment(source[segmentRange], out segments[segmentIndex++]))
-				{
-					result = null;
-					return false;
-				}
+		{			
+			if (!TryDecodeSegment(source[segmentRange], out segments[segmentIndex++]))
+			{
+				result = null;
+				return false;
+			}	
 		}
 
 		result = new JsonPointer(segments);
@@ -159,31 +159,25 @@ public class JsonPointer : IEquatable<JsonPointer>, IReadOnlyList<string>
 		var segmentCount = CountSegments(source);
 		var segments = new string[segmentCount];
 
-		var part = source;
+		source = source[1..];
 		var segmentIndex = 0;
 		result = null;
 
-		var sourceIndex = part.IndexOf('/');
+		var sourceIndex = source.IndexOf('/');
 		while (sourceIndex >= 0)
 		{
-			if (!TryDecodeSegment(part[..sourceIndex], out var segment))
+			if (!TryDecodeSegment(source[..sourceIndex], out var segment))
 				return false;
 
-			if (segment.Length != 0)
-			{
-				segments[segmentIndex++] = segment;
-			}
-
-			part = part[(sourceIndex + 1)..];
-			sourceIndex = part.IndexOf('/');
+			segments[segmentIndex++] = segment;
+			
+			source = source[(sourceIndex + 1)..];
+			sourceIndex = source.IndexOf('/');
 		}
 
-		if (part.Length != 0)
-		{
-			if (!TryDecodeSegment(part, out segments[segmentIndex]))
-				return false;
-		}
-
+		if (!TryDecodeSegment(source, out segments[segmentIndex]))
+			return false;
+		
 		result = new JsonPointer(segments);
 		return true;
 	}

--- a/src/JsonPointer/JsonPointer.csproj
+++ b/src/JsonPointer/JsonPointer.csproj
@@ -16,8 +16,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>JsonPointer.Net</PackageId>
-    <Version>5.2.0</Version>
-    <FileVersion>5.2.0</FileVersion>
+    <Version>5.3.0</Version>
+    <FileVersion>5.3.0</FileVersion>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>JSON Pointer built on the System.Text.Json namespace</Description>

--- a/src/JsonPointer/SpanExtensions.cs
+++ b/src/JsonPointer/SpanExtensions.cs
@@ -4,46 +4,6 @@ namespace Json.Pointer;
 
 internal static class SpanExtensions
 {
-	internal static char Decode(this ReadOnlySpan<char> value, ref int index)
-	{
-		var ch = value[index];
-		if (ch == '~')
-		{
-			if (index + 1 >= value.Length)
-				throw new PointerParseException($"Value '{value.ToString()}' does not represent a valid JSON Pointer segment");
-			ch = value[index + 1] switch
-			{
-				'0' => '~',
-				'1' => '/',
-				_ => throw new PointerParseException($"Value '{value.ToString()}' does not represent a valid JSON Pointer segment")
-			};
-			index++;
-		}
-
-		return ch;
-	}
-
-	internal static bool TryDecode(this ReadOnlySpan<char> value, ref int index, out char ch)
-	{
-		ch = value[index];
-		
-		if (ch != '~') return true;
-		if (index + 1 >= value.Length) return false;
-
-		index++;
-		switch (value[index])
-		{
-			case '0':
-				ch = '~';
-				return true;
-			case '1':
-				ch = '/';
-				return true;
-			default:
-				return false;
-		}
-	}
-
 	internal static int Encode(this ReadOnlySpan<char> key, Span<char> encoded)
 	{
 		var length = 0;

--- a/src/JsonPointer/SpanExtensions.cs
+++ b/src/JsonPointer/SpanExtensions.cs
@@ -1,9 +1,60 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Json.Pointer;
 
 internal static class SpanExtensions
 {
+	internal static bool TryDecodeSegment(this ReadOnlySpan<char> encoded, [NotNullWhen(true)] out string? result)
+	{
+		var l = encoded.Length;
+		if (l == 0)
+		{
+			result = string.Empty;
+			return true;
+		}
+
+		var targetIndex = 0;
+		var sourceIndex = 0;
+		result = null;
+
+		Span<char> target = l < 1024
+			? stackalloc char[l]
+			: new char[l];
+
+		for (; sourceIndex < l; targetIndex++, sourceIndex++)
+		{
+			target[targetIndex] = encoded[sourceIndex];
+
+			if (target[targetIndex] == '/')
+			{
+				return false;
+			}
+
+			if (target[targetIndex] == '~')
+			{
+				if (sourceIndex == l - 1)
+					return false;
+
+				if (encoded[++sourceIndex] == '0')
+					continue; // we already wrote '~' so we're good
+
+				if (encoded[sourceIndex] == '1')
+					target[targetIndex] = '/';
+				else
+					return false; // invalid escape sequence
+			}
+		}
+
+#if NET8_0_OR_GREATER
+		result = new string(target[..targetIndex]);
+#else
+		result = target[..targetIndex].ToString();
+#endif
+
+		return true;
+	}
+
 	internal static int Encode(this ReadOnlySpan<char> key, Span<char> encoded)
 	{
 		var length = 0;

--- a/src/JsonSchema.Tests/LocalizationTests.cs
+++ b/src/JsonSchema.Tests/LocalizationTests.cs
@@ -7,7 +7,7 @@ namespace Json.Schema.Tests;
 
 public class LocalizationTests
 {
-	[Test]
+	[Test, SetCulture("en-US")]
 	public void MinimumReturnsDefaultErrorMessage()
 	{
 		JsonSchema schema = new JsonSchemaBuilder()

--- a/src/JsonSchema.Tests/OutputTests.cs
+++ b/src/JsonSchema.Tests/OutputTests.cs
@@ -7,6 +7,7 @@ using TestHelpers;
 
 namespace Json.Schema.Tests;
 
+[TestFixture, SetCulture("en-US")]
 public class OutputTests
 {
 	private static readonly JsonSchema _schema =

--- a/src/JsonSchema/nuspec/JsonSchema.Net.nuspec
+++ b/src/JsonSchema/nuspec/JsonSchema.Net.nuspec
@@ -13,7 +13,7 @@
     <tags>json-schema validation schema json</tags>
     <repository type="git" url="https://github.com/json-everything/json-everything" />
     <dependencies>
-      <dependency id="JsonPointer.Net" version="5.2.0" exclude="Build,Analyzers" />
+      <dependency id="JsonPointer.Net" version="5.3.0" exclude="Build,Analyzers" />
     </dependencies>
   </metadata>
   <files>

--- a/tools/ApiDocsGenerator/release-notes/rn-json-pointer.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-pointer.md
@@ -4,6 +4,11 @@ title: JsonPointer.Net
 icon: fas fa-tag
 order: "09.10"
 ---
+# [5.3.0](https://github.com/json-everything/json-everything/pull/850) {#release-pointer-5.3.0}
+
+[#849](https://github.com/json-everything/json-everything/issues/849) - Avoid memory leak in, and improve performance of JsonPointer.ToString() courtesy of [@cptjazz](https://github.com/cptjazz). 
+[#855](https://github.com/json-everything/json-everything/issues/855) - Performance improvements for JsonPointer.Parse()/TryParse() courtesy of [@cptjazz](https://github.com/cptjazz). 
+
 # [5.2.0](https://github.com/gregsdennis/json-everything/pull/848) {#release-pointer-5.2.0}
 
 [#843](https://github.com/json-everything/json-everything/pull/843) - Performance improvements courtesy of [@cptjazz](https://github.com/cptjazz).

--- a/tools/Benchmarks/Pointer/Runner.cs
+++ b/tools/Benchmarks/Pointer/Runner.cs
@@ -40,12 +40,31 @@ public class Runner
 		"#/%20",
 		"#/m~0n",
 	];
-	
-	[Params(1,10,100)]
+
+	private static readonly string[] _segments = 
+	[
+		"user",
+		"name",
+		"age",
+		"g%7Ch",
+		"theme",
+		"notifications",
+		"email",
+		"m~0n",
+		"comments",
+		"metadata",
+		"version",
+		"a~1b",
+		"errors",
+		"message",
+		"a~0b"
+	];
+
+	[Params(1, 10, 100)]
 	public int Count { get; set; }
 
 	[Benchmark]
-	public int Run()
+	public int Parse()
 	{
 		for (int i = 0; i < Count; i++)
 		{
@@ -56,5 +75,21 @@ public class Runner
 		}
 
 		return Count;
+	}
+
+	[Benchmark]
+	public JsonPointer Combine()
+	{
+		var p = JsonPointer.Empty;
+
+		for (int i = 0; i < Count; i++)
+		{
+			foreach (var test in _pointersToParse)
+			{
+				p = p.Combine(_segments[i % _segments.Length]);
+			}
+		}
+
+		return p;
 	}
 }

--- a/tools/Benchmarks/Pointer/Runner.cs
+++ b/tools/Benchmarks/Pointer/Runner.cs
@@ -60,6 +60,10 @@ public class Runner
 		"a~0b"
 	];
 
+	private static readonly JsonPointer[] _pointers = _pointersToParse
+		.Select(JsonPointer.Parse)
+		.ToArray();
+
 	[Params(1, 10, 100)]
 	public int Count { get; set; }
 
@@ -91,5 +95,21 @@ public class Runner
 		}
 
 		return p;
+	}
+
+	[Benchmark]
+	public string PointerToString()
+	{
+		var s = string.Empty;
+
+		for (int i = 0; i < Count; i++)
+		{
+			foreach (var test in _pointersToParse)
+			{
+				s = _pointers[i % _segments.Length].ToString();
+			}
+		}
+
+		return s;
 	}
 }

--- a/tools/Benchmarks/Pointer/Runner.cs
+++ b/tools/Benchmarks/Pointer/Runner.cs
@@ -1,10 +1,13 @@
 ﻿using BenchmarkDotNet.Attributes;
 ﻿using System.Linq;
 using Json.Pointer;
+using BenchmarkDotNet.Jobs;
 
 namespace Json.Benchmarks.Pointer;
 
 [MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net90)]
 public class Runner
 {
 	private static readonly string[] _pointersToParse =

--- a/tools/Benchmarks/Pointer/Runner.cs
+++ b/tools/Benchmarks/Pointer/Runner.cs
@@ -1,4 +1,5 @@
 ﻿using BenchmarkDotNet.Attributes;
+﻿using System.Linq;
 using Json.Pointer;
 
 namespace Json.Benchmarks.Pointer;

--- a/tools/Benchmarks/Program.cs
+++ b/tools/Benchmarks/Program.cs
@@ -15,11 +15,11 @@ class Program
 		//config.WithOptions(ConfigOptions.DisableOptimizationsValidator);
 		//var summary = BenchmarkRunner.Run<TestSuiteRunner>(config);
 
-		var runner = new SuiteRunner();
-		runner.BenchmarkSetup();
-		runner.Models();
+		var runner = new Runner();
+		runner.Parse();
+		
 #else
-		var summary = BenchmarkRunner.Run<TestSuiteRunner>();
+		var summary = BenchmarkRunner.Run<Runner>();
 #endif
 	}
 }


### PR DESCRIPTION
### Description
Properly disposes of the rented memory, and also sets the minimum buffer size when renting, to avoid (some) buffer resizings, since we already have the segment length at hand.

### Links

Fixes #849

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
