### PR TITLE
fix #856; allow enum serialization with duplicated member values

### DIFF
--- a/src/Json.More.Tests/EnumStringConverterTests.cs
+++ b/src/Json.More.Tests/EnumStringConverterTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using NUnit.Framework;
@@ -77,5 +78,26 @@ public class EnumStringConverterTests
 		var deserialized = JsonSerializer.Deserialize<FlagsEnumContainer>(actual)!;
 
 		Assert.That(deserialized.Value, Is.EqualTo(CustomFlagsEnum.One | CustomFlagsEnum.Two));
+	}
+
+	private class EnumWithDuplicatedMemberValuesContainer
+	{
+		[JsonConverter(typeof(EnumStringConverter<HttpStatusCode>))]
+		public HttpStatusCode Value { get; set; }
+	}
+
+	[Test]
+	public void EnumWithDuplicatedMemberValuesIsConverted()
+	{
+		var value = new EnumWithDuplicatedMemberValuesContainer { Value = HttpStatusCode.MultipleChoices };
+
+		var expected = "{\"Value\":\"MultipleChoices\"}";
+		var actual = JsonSerializer.Serialize(value);
+
+		Assert.That(actual, Is.EqualTo(expected));
+
+		var deserialized = JsonSerializer.Deserialize<EnumWithDuplicatedMemberValuesContainer>(actual)!;
+
+		Assert.That(deserialized.Value, Is.EqualTo(HttpStatusCode.MultipleChoices));
 	}
 }

--- a/src/Json.More/EnumStringConverter.cs
+++ b/src/Json.More/EnumStringConverter.cs
@@ -177,16 +177,29 @@ public class EnumStringConverter<[DynamicallyAccessedMembers(DynamicallyAccessed
 		{
 			if (_readValues != null && _writeValues != null) return;
 
-			var map = typeof(T).GetFields()
-				.Where(f => !f.IsSpecialName)
-				.Select(f => new
-				{
-					Value = (T)Enum.Parse(typeof(T), f.Name),
-					Description = f.GetCustomAttribute<DescriptionAttribute>()?.Description ?? f.Name
-				})
-				.ToList();
-			_readValues = map.ToDictionary(v => v.Description, v => v.Value);
-			_writeValues = map.ToDictionary(v => v.Value, v => v.Description);
+			var fields = typeof(T).GetFields();
+
+			var readValues = new Dictionary<string, T>(capacity: fields.Length);
+			var writeValues = new Dictionary<T, string>(capacity: fields.Length);
+
+			foreach (var field in fields.Where(f => !f.IsSpecialName))
+			{
+				var value = (T) Enum.Parse(typeof(T), field.Name);
+				var description = field.GetCustomAttribute<DescriptionAttribute>()?.Description ?? field.Name;
+
+#if NET8_0_OR_GREATER
+				readValues.TryAdd(description, value);
+				writeValues.TryAdd(value, description);
+#else
+				if (!readValues.ContainsKey(description))
+					readValues.Add(description, value);
+				if (!writeValues.ContainsKey(value))
+					writeValues.Add(value, description);
+#endif
+			}
+
+			_readValues = readValues;
+			_writeValues = writeValues;
 		}
 	}
 }

--- a/src/Json.More/EnumStringConverter.cs
+++ b/src/Json.More/EnumStringConverter.cs
@@ -187,15 +187,10 @@ public class EnumStringConverter<[DynamicallyAccessedMembers(DynamicallyAccessed
 				var value = (T) Enum.Parse(typeof(T), field.Name);
 				var description = field.GetCustomAttribute<DescriptionAttribute>()?.Description ?? field.Name;
 
-#if NET8_0_OR_GREATER
-				readValues.TryAdd(description, value);
-				writeValues.TryAdd(value, description);
-#else
 				if (!readValues.ContainsKey(description))
 					readValues.Add(description, value);
 				if (!writeValues.ContainsKey(value))
 					writeValues.Add(value, description);
-#endif
 			}
 
 			_readValues = readValues;

--- a/src/Json.More/Json.More.csproj
+++ b/src/Json.More/Json.More.csproj
@@ -14,8 +14,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>Json.More.Net</PackageId>
-    <Version>2.1.0</Version>
-    <FileVersion>2.1.0</FileVersion>
+    <Version>2.1.1</Version>
+    <FileVersion>2.1.1</FileVersion>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>Provides extended functionality for the System.Text.Json namespace.</Description>

--- a/tools/ApiDocsGenerator/release-notes/rn-json-more.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-more.md
@@ -4,6 +4,10 @@ title: Json.More.Net
 icon: fas fa-tag
 order: "09.13"
 ---
+# [2.1.1](https://github.com/json-everything/json-everything/pull/857) {#release-more-2.1.1}
+
+[#856](https://github.com/json-everything/json-everything/issues/856) - `EnumStringConverter` fails on Enum serialization when multiple members have same value
+
 # [2.1.0](https://github.com/gregsdennis/json-everything/pull/822) {#release-more-2.1.0}
 
 Add .Net 9.0 support.


### PR DESCRIPTION
### Description

Allow enum serialization with duplicated member values.

This does not affect the public API surface;
The changes does not cause breaks in either developer experience or behavior;

### Links

Resolves  #856

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
