### PR TITLE
RelativeJsonPointer: use span APIs when on .NET8+

### DIFF
--- a/src/JsonPointer/JsonPointer.cs
+++ b/src/JsonPointer/JsonPointer.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -540,7 +541,7 @@ public class JsonPointer : IEquatable<JsonPointer>, IReadOnlyList<string>
 					}
 					if (segment[0] == '0') return null;
 					if (segment is ['-']) return current.EnumerateArray().LastOrDefault();
-					if (!int.TryParse(segment, out var index)) return null;
+					if (!int.TryParse(segment, NumberStyles.Integer, CultureInfo.InvariantCulture, out var index)) return null;
 					if (index >= current.GetArrayLength()) return null;
 					if (index < 0) return null;
 

--- a/src/JsonPointer/JsonPointer.csproj
+++ b/src/JsonPointer/JsonPointer.csproj
@@ -16,8 +16,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>JsonPointer.Net</PackageId>
-    <Version>5.3.0</Version>
-    <FileVersion>5.3.0</FileVersion>
+    <Version>5.3.1</Version>
+    <FileVersion>5.3.1</FileVersion>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>JSON Pointer built on the System.Text.Json namespace</Description>

--- a/src/JsonPointer/PointerSegment.cs
+++ b/src/JsonPointer/PointerSegment.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace Json.Pointer;
 
@@ -19,7 +20,7 @@ public readonly struct PointerSegment
 	/// </summary>
 	/// <param name="value">A pointer segment that represents the value.</param>
 	public static implicit operator PointerSegment(int value) =>
-		new(value.ToString());
+		new(value.ToString(CultureInfo.InvariantCulture));
 
 	/// <summary>
 	/// Implicitly casts a <see cref="string"/> to a <see cref="PointerSegment"/>.

--- a/src/JsonPointer/RelativeJsonPointer.cs
+++ b/src/JsonPointer/RelativeJsonPointer.cs
@@ -122,7 +122,12 @@ public class RelativeJsonPointer
 		while (i < span.Length && char.IsDigit(span[i])) i++;
 		if (i == 0) throw new PointerParseException($"`{nameof(source)}` must start with a non-negative integer");
 
+#if NET8_0_OR_GREATER
+		var parentSteps = uint.Parse(span[..i]);
+#else
 		var parentSteps = uint.Parse(span[..i].ToString());
+#endif
+
 		if (i == span.Length) return new RelativeJsonPointer(parentSteps, JsonPointer.Empty);
 
 		int indexManipulation = 0;
@@ -132,7 +137,13 @@ public class RelativeJsonPointer
 			i++;
 			var start = i;
 			while (i < span.Length && char.IsDigit(span[i])) i++;
+
+#if NET8_0_OR_GREATER
+			indexManipulation = sign * int.Parse(span[start..i]);
+#else
 			indexManipulation = sign * int.Parse(span[start..i].ToString());
+#endif
+
 			if (i == span.Length) return new RelativeJsonPointer(parentSteps, indexManipulation, JsonPointer.Empty);
 		}
 		if (span[i] == '#')
@@ -143,7 +154,7 @@ public class RelativeJsonPointer
 
 		if (span[i] != '/') throw new PointerParseException($"{nameof(source)} must contain either a `#` or a pointer after the initial number");
 
-		var pointer = JsonPointer.Parse(span[i..].ToString());
+		var pointer = JsonPointer.Parse(span[i..]);
 
 		return new RelativeJsonPointer(parentSteps, indexManipulation, pointer);
 	}
@@ -174,7 +185,12 @@ public class RelativeJsonPointer
 			return false;
 		}
 
+#if NET8_0_OR_GREATER
+		var parentSteps = uint.Parse(span[..i]);
+#else
 		var parentSteps = uint.Parse(span[..i].ToString());
+#endif
+
 		if (i == span.Length)
 		{
 			relativePointer = new RelativeJsonPointer(parentSteps, JsonPointer.Empty);
@@ -188,7 +204,12 @@ public class RelativeJsonPointer
 			i++;
 			var start = i;
 			while (i < span.Length && char.IsDigit(span[i])) i++;
+
+#if NET8_0_OR_GREATER
+			indexManipulation = sign * int.Parse(span[start..i]);
+#else
 			indexManipulation = sign * int.Parse(span[start..i].ToString());
+#endif
 			if (i == span.Length)
 			{
 				relativePointer = new RelativeJsonPointer(parentSteps, indexManipulation, JsonPointer.Empty);
@@ -212,7 +233,7 @@ public class RelativeJsonPointer
 			return false;
 		}
 
-		if (!JsonPointer.TryParse(span[i..].ToString(), out var pointer))
+		if (!JsonPointer.TryParse(span[i..], out var pointer))
 		{
 			relativePointer = null;
 			return false;

--- a/src/JsonPointer/RelativeJsonPointer.cs
+++ b/src/JsonPointer/RelativeJsonPointer.cs
@@ -122,11 +122,7 @@ public class RelativeJsonPointer
 		while (i < span.Length && char.IsDigit(span[i])) i++;
 		if (i == 0) throw new PointerParseException($"`{nameof(source)}` must start with a non-negative integer");
 
-#if NET8_0_OR_GREATER
-		var parentSteps = uint.Parse(span[..i]);
-#else
-		var parentSteps = uint.Parse(span[..i].ToString());
-#endif
+		var parentSteps = span[..i].AsUint();
 
 		if (i == span.Length) return new RelativeJsonPointer(parentSteps, JsonPointer.Empty);
 
@@ -138,11 +134,7 @@ public class RelativeJsonPointer
 			var start = i;
 			while (i < span.Length && char.IsDigit(span[i])) i++;
 
-#if NET8_0_OR_GREATER
-			indexManipulation = sign * int.Parse(span[start..i]);
-#else
-			indexManipulation = sign * int.Parse(span[start..i].ToString());
-#endif
+			indexManipulation = sign * span[start..i].AsInt();
 
 			if (i == span.Length) return new RelativeJsonPointer(parentSteps, indexManipulation, JsonPointer.Empty);
 		}
@@ -185,11 +177,7 @@ public class RelativeJsonPointer
 			return false;
 		}
 
-#if NET8_0_OR_GREATER
-		var parentSteps = uint.Parse(span[..i]);
-#else
-		var parentSteps = uint.Parse(span[..i].ToString());
-#endif
+		var parentSteps = span[..i].AsUint();
 
 		if (i == span.Length)
 		{
@@ -205,11 +193,8 @@ public class RelativeJsonPointer
 			var start = i;
 			while (i < span.Length && char.IsDigit(span[i])) i++;
 
-#if NET8_0_OR_GREATER
-			indexManipulation = sign * int.Parse(span[start..i]);
-#else
-			indexManipulation = sign * int.Parse(span[start..i].ToString());
-#endif
+			indexManipulation = sign * span[start..i].AsInt();
+
 			if (i == span.Length)
 			{
 				relativePointer = new RelativeJsonPointer(parentSteps, indexManipulation, JsonPointer.Empty);

--- a/src/JsonPointer/UtilityExtensions.cs
+++ b/src/JsonPointer/UtilityExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace Json.Pointer;
 
@@ -7,18 +8,18 @@ internal static class UtilityExtensions
 	public static int AsInt(this ReadOnlySpan<char> value)
 	{
 #if NET8_0_OR_GREATER
-		return int.Parse(value);
+		return int.Parse(value, CultureInfo.InvariantCulture);
 #else
-		return int.Parse(value.ToString());
+		return int.Parse(value.ToString(), CultureInfo.InvariantCulture);
 #endif
 	}
 
 	public static uint AsUint(this ReadOnlySpan<char> value)
 	{
 #if NET8_0_OR_GREATER
-		return uint.Parse(value);
+		return uint.Parse(value, CultureInfo.InvariantCulture);
 #else
-		return uint.Parse(value.ToString());
+		return uint.Parse(value.ToString(), CultureInfo.InvariantCulture);
 #endif
 	}
 }

--- a/src/JsonPointer/UtilityExtensions.cs
+++ b/src/JsonPointer/UtilityExtensions.cs
@@ -8,18 +8,18 @@ internal static class UtilityExtensions
 	public static int AsInt(this ReadOnlySpan<char> value)
 	{
 #if NET8_0_OR_GREATER
-		return int.Parse(value, CultureInfo.InvariantCulture);
+		return int.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
 #else
-		return int.Parse(value.ToString(), CultureInfo.InvariantCulture);
+		return int.Parse(value.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture);
 #endif
 	}
 
 	public static uint AsUint(this ReadOnlySpan<char> value)
 	{
 #if NET8_0_OR_GREATER
-		return uint.Parse(value, CultureInfo.InvariantCulture);
+		return uint.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
 #else
-		return uint.Parse(value.ToString(), CultureInfo.InvariantCulture);
+		return uint.Parse(value.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture);
 #endif
 	}
 }

--- a/src/JsonPointer/UtilityExtensions.cs
+++ b/src/JsonPointer/UtilityExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace Json.Pointer;
+
+internal static class UtilityExtensions
+{
+	public static int AsInt(this ReadOnlySpan<char> value)
+	{
+#if NET8_0_OR_GREATER
+		return int.Parse(value);
+#else
+		return int.Parse(value.ToString());
+#endif
+	}
+
+	public static uint AsUint(this ReadOnlySpan<char> value)
+	{
+#if NET8_0_OR_GREATER
+		return uint.Parse(value);
+#else
+		return uint.Parse(value.ToString());
+#endif
+	}
+}

--- a/tools/ApiDocsGenerator/release-notes/rn-json-pointer.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-pointer.md
@@ -4,6 +4,11 @@ title: JsonPointer.Net
 icon: fas fa-tag
 order: "09.10"
 ---
+# [5.3.1](https://github.com/json-everything/json-everything/pull/864) {#release-pointer-5.3.1}
+
+[#863](https://github.com/json-everything/json-everything/issues/863) - Performance improvements for RelativeJsonPointer courtesy of [@cptjazz](https://github.com/cptjazz). 
+Fixed a potential localization issue when parsing JSON pointer array indices.
+
 # [5.3.0](https://github.com/json-everything/json-everything/pull/850) {#release-pointer-5.3.0}
 
 [#849](https://github.com/json-everything/json-everything/issues/849) - Avoid memory leak in, and improve performance of JsonPointer.ToString() courtesy of [@cptjazz](https://github.com/cptjazz). 


### PR DESCRIPTION
### Description

Use modern Span-based APIs to avoid allocations when parsing RelativeJsonPointer

### Links

Resolves #863 
Depends on #868 

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
