### PR TITLE
Changed Date and Time validation to not validate against the DateTime…

### DIFF
--- a/src/JsonSchema.Tests/Files/Issue881_schema.json
+++ b/src/JsonSchema.Tests/Files/Issue881_schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "description": "Schema for issue 881",
+  "properties": {
+    "oneOfDates": {
+      "title": "Dates that have a oneOf conditional schema",
+      "type": "string",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date"
+        },
+        {
+          "type": "string",
+          "format": "date-time"
+        }
+      ]
+    },
+    "dateWithDateFormat": {
+      "title": "Property with date defined format",
+      "type": "string",
+      "format": "date"
+    },
+    "timeWithTimeFormat": {
+      "title": "Property with time defined format",
+      "type": "string",
+      "format": "time"
+    }
+  }
+}

--- a/src/JsonSchema.Tests/GithubTests.cs
+++ b/src/JsonSchema.Tests/GithubTests.cs
@@ -961,6 +961,108 @@ public class GithubTests
 	}
 
 	[Test]
+	public void Issue881_DateTimeValidationPassesWithOneOfSchema()
+	{
+		var file = GetFile(881, "schema");
+
+		var schema = JsonSchema.FromFile(file);
+
+		var instance = new JsonObject()
+		{
+				new KeyValuePair<string, JsonNode?>("oneOfDates", "2025-01-02T23:03:22.222Z")
+		};
+
+		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List });
+
+		result.AssertValid();
+	}
+
+	[Test]
+	public void Issue881_DateValidationPassesWithOneOfSchema()
+	{
+		var file = GetFile(881, "schema");
+
+		var schema = JsonSchema.FromFile(file);
+
+		var instance = new JsonObject()
+		{
+				new KeyValuePair<string, JsonNode?>("oneOfDates", "2025-01-02")
+		};
+
+		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List });
+
+		result.AssertValid();
+	}
+
+	[Test]
+	public void Issue881_DateValidationFailsAgainstDateTime()
+	{
+		var file = GetFile(881, "schema");
+
+		var schema = JsonSchema.FromFile(file);
+
+		var instance = new JsonObject()
+		{
+				new KeyValuePair<string, JsonNode?>("dateWithDateFormat", "2025-01-02T23:03:22.222Z")
+		};
+
+		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List });
+
+		result.AssertInvalid();
+	}
+
+	[Test]
+	public void Issue881_DateValidationPassesAgainstDate()
+	{
+		var file = GetFile(881, "schema");
+
+		var schema = JsonSchema.FromFile(file);
+
+		var instance = new JsonObject()
+		{
+				new KeyValuePair<string, JsonNode?>("dateWithDateFormat", "2025-01-02")
+		};
+
+		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List });
+
+		result.AssertValid();
+	}
+
+	[Test]
+	public void Issue881_TimeValidationFailsAgainstDateTime()
+	{
+		var file = GetFile(881, "schema");
+
+		var schema = JsonSchema.FromFile(file);
+
+		var instance = new JsonObject()
+		{
+				new KeyValuePair<string, JsonNode?>("timeWithTimeFormat", "2025-01-02T23:03:22.222Z")
+		};
+
+		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List });
+
+		result.AssertInvalid();
+	}
+
+	[Test]
+	public void Issue881_TimeValidationPassesAgainstTime()
+	{
+		var file = GetFile(881, "schema");
+
+		var schema = JsonSchema.FromFile(file);
+
+		var instance = new JsonObject()
+		{
+				new KeyValuePair<string, JsonNode?>("timeWithTimeFormat", "23:03:22")
+		};
+
+		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List });
+
+		result.AssertValid();
+	}
+
+	[Test]
 	public void Issue664_UIntConstNotValidating()
 	{
 		var schema = new JsonSchemaBuilder()

--- a/src/JsonSchema.Tests/GithubTests.cs
+++ b/src/JsonSchema.Tests/GithubTests.cs
@@ -969,7 +969,7 @@ public class GithubTests
 
 		var instance = new JsonObject()
 		{
-				new KeyValuePair<string, JsonNode?>("oneOfDates", "2025-01-02T23:03:22.222Z")
+			["oneOfDates"] = "2025-01-02T23:03:22.222Z"
 		};
 
 		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List });
@@ -986,7 +986,7 @@ public class GithubTests
 
 		var instance = new JsonObject()
 		{
-				new KeyValuePair<string, JsonNode?>("oneOfDates", "2025-01-02")
+			["oneOfDates"] = "2025-01-02"
 		};
 
 		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List });
@@ -1003,7 +1003,7 @@ public class GithubTests
 
 		var instance = new JsonObject()
 		{
-				new KeyValuePair<string, JsonNode?>("dateWithDateFormat", "2025-01-02T23:03:22.222Z")
+			["dateWithDateFormat"] = "2025-01-02T23:03:22.222Z"
 		};
 
 		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List });
@@ -1020,7 +1020,7 @@ public class GithubTests
 
 		var instance = new JsonObject()
 		{
-				new KeyValuePair<string, JsonNode?>("dateWithDateFormat", "2025-01-02")
+			["dateWithDateFormat"] = "2025-01-02"
 		};
 
 		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List });
@@ -1037,7 +1037,7 @@ public class GithubTests
 
 		var instance = new JsonObject()
 		{
-				new KeyValuePair<string, JsonNode?>("timeWithTimeFormat", "2025-01-02T23:03:22.222Z")
+			["timeWithTimeFormat"] = "2025-01-02T23:03:22.222Z"
 		};
 
 		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List });
@@ -1054,7 +1054,7 @@ public class GithubTests
 
 		var instance = new JsonObject()
 		{
-				new KeyValuePair<string, JsonNode?>("timeWithTimeFormat", "23:03:22")
+			["timeWithTimeFormat"] = "23:03:22"
 		};
 
 		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List });

--- a/src/JsonSchema.Tests/GithubTests.cs
+++ b/src/JsonSchema.Tests/GithubTests.cs
@@ -961,7 +961,7 @@ public class GithubTests
 	}
 
 	[Test]
-	public void Issue881_DateTimeValidationPassesWithOneOfSchema()
+	public void Issue881_UsingSchema201909DateTimeValidationPassesWithOneOfSchema()
 	{
 		var file = GetFile(881, "schema");
 
@@ -978,7 +978,7 @@ public class GithubTests
 	}
 
 	[Test]
-	public void Issue881_DateValidationPassesWithOneOfSchema()
+	public void Issue881_UsingSchema201909DateValidationPassesWithOneOfSchema()
 	{
 		var file = GetFile(881, "schema");
 
@@ -995,7 +995,7 @@ public class GithubTests
 	}
 
 	[Test]
-	public void Issue881_DateValidationFailsAgainstDateTime()
+	public void Issue881_UsingSchema201909DateValidationFailsAgainstDateTimeFormat()
 	{
 		var file = GetFile(881, "schema");
 
@@ -1012,7 +1012,7 @@ public class GithubTests
 	}
 
 	[Test]
-	public void Issue881_DateValidationPassesAgainstDate()
+	public void Issue881_UsingSchema201909DateValidationPassesAgainstDateFormat()
 	{
 		var file = GetFile(881, "schema");
 
@@ -1029,7 +1029,7 @@ public class GithubTests
 	}
 
 	[Test]
-	public void Issue881_TimeValidationFailsAgainstDateTime()
+	public void Issue881_UsingSchema201909TimeValidationFailsAgainstDateTimeFormat()
 	{
 		var file = GetFile(881, "schema");
 
@@ -1046,7 +1046,7 @@ public class GithubTests
 	}
 
 	[Test]
-	public void Issue881_TimeValidationPassesAgainstTime()
+	public void Issue881_UsingSchema201909TimeValidationPassesAgainstTimeFormat()
 	{
 		var file = GetFile(881, "schema");
 

--- a/src/JsonSchema.Tests/GithubTests.cs
+++ b/src/JsonSchema.Tests/GithubTests.cs
@@ -972,7 +972,7 @@ public class GithubTests
 			["oneOfDates"] = "2025-01-02T23:03:22.222Z"
 		};
 
-		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List });
+		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List, RequireFormatValidation = true });
 
 		result.AssertValid();
 	}
@@ -989,7 +989,7 @@ public class GithubTests
 			["oneOfDates"] = "2025-01-02"
 		};
 
-		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List });
+		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List, RequireFormatValidation = true });
 
 		result.AssertValid();
 	}
@@ -1006,7 +1006,7 @@ public class GithubTests
 			["dateWithDateFormat"] = "2025-01-02T23:03:22.222Z"
 		};
 
-		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List });
+		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List, RequireFormatValidation = true });
 
 		result.AssertInvalid();
 	}
@@ -1023,7 +1023,7 @@ public class GithubTests
 			["dateWithDateFormat"] = "2025-01-02"
 		};
 
-		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List });
+		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List, RequireFormatValidation = true });
 
 		result.AssertValid();
 	}
@@ -1040,7 +1040,7 @@ public class GithubTests
 			["timeWithTimeFormat"] = "2025-01-02T23:03:22.222Z"
 		};
 
-		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List });
+		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List, RequireFormatValidation = true });
 
 		result.AssertInvalid();
 	}
@@ -1057,7 +1057,7 @@ public class GithubTests
 			["timeWithTimeFormat"] = "23:03:22"
 		};
 
-		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List });
+		var result = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.List, RequireFormatValidation = true });
 
 		result.AssertValid();
 	}

--- a/src/JsonSchema/Formats.cs
+++ b/src/JsonSchema/Formats.cs
@@ -309,7 +309,12 @@ public static partial class Formats
 
 	private static bool CheckDateTime(JsonNode? node)
 	{
-		return CheckDateFormat(node);
+		if (!CheckDateFormat(node))
+		{
+			return CheckDateTimePrecisionFormat(node);
+		}
+
+		return true;
 	}
 
 	private static bool CheckDateFormat(JsonNode? node, params string[] formats)
@@ -323,11 +328,19 @@ public static partial class Formats
 			if (canParseExact) return true;
 		}
 
+		return false;
+	}
+
+	private static bool CheckDateTimePrecisionFormat(JsonNode? node)
+	{
+		if (node.GetSchemaValueType() != SchemaValueType.String) return true;
+
+		var dateString = node!.GetValue<string>().ToUpperInvariant();
+
 		// date-times with very high precision don't get matched by TryParseExact but are still actually parsable.
 		// We use a fallback to catch these cases
 		var match = DateTimeRegex().Match(dateString);
 		return match.Success;
-
 	}
 
 	private static bool CheckHostName(JsonNode? node)

--- a/src/JsonSchema/JsonSchema.csproj
+++ b/src/JsonSchema/JsonSchema.csproj
@@ -17,7 +17,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
 
     <PackageId>JsonSchema.Net</PackageId>
-    <JsonSchemaNetVersion>7.3.3</JsonSchemaNetVersion>
+    <JsonSchemaNetVersion>7.3.4</JsonSchemaNetVersion>
     <AssemblyVersion>7.0.0.0</AssemblyVersion>
     <FileVersion>$(JsonSchemaNetVersion)</FileVersion>
     <Authors>Greg Dennis</Authors>


### PR DESCRIPTION
### Description
Changed Date and Time validation to not validate against the DateTime RegEx format.

The added unit tests could be removed if the cases are added to the JSON-Schema-Test-Suite.
Let me know if I should add them there and remove them from this PR.

These changes _could_ break existing implementations due to the fact that `date` and `time` formats would historically have a valid validation, which with these changes will change to an invalid validation.

### Links

This should resolve #881 and is related to #558

### Checks

- [ x ] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
