### PR TITLE
JsonArrayTupleConverter is no longer valid for arrays of tuples.

### DIFF
--- a/src/Json.More.Tests/JsonArrayTupleConverterDeserializationTests.cs
+++ b/src/Json.More.Tests/JsonArrayTupleConverterDeserializationTests.cs
@@ -120,4 +120,15 @@ public class JsonArrayTupleConverterDeserializationTests
 
 		Assert.That(actual, Is.EqualTo(expected));
 	}
+
+	[Test]
+	public void TupleInArray()
+	{
+		(int, string, bool, double, string, int, int, int)[] expected = [(1, "string", false, -4.2, "foo", 6, 7, 8), (10, "bool", true, 4.2, "bar", 6, 7, 8)];
+		var json = "[[1,\"string\",false,-4.2,\"foo\",6,7,8],[10,\"bool\",true,4.2,\"bar\",6,7,8]]";
+
+		var actual = JsonSerializer.Deserialize<(int, string, bool, double, string, int, int, int)[]>(json, _options);
+
+		Assert.That(actual, Is.EqualTo(expected));
+	}
 }

--- a/src/Json.More.Tests/JsonArrayTupleConverterSerializationTests.cs
+++ b/src/Json.More.Tests/JsonArrayTupleConverterSerializationTests.cs
@@ -120,4 +120,15 @@ public class JsonArrayTupleConverterSerializationTests
 
 		Assert.That(actual, Is.EqualTo(expected));
 	}
+
+	[Test]
+	public void TupleInArray()
+	{
+		(int, string, bool, double, string, int, int, int)[] tuple = [(1, "string", false, -4.2, "foo", 6, 7, 8), (10, "bool", true, 4.2, "bar", 6, 7, 8)];
+		var expected = "[[1,\"string\",false,-4.2,\"foo\",6,7,8],[10,\"bool\",true,4.2,\"bar\",6,7,8]]";
+
+		var actual = JsonSerializer.Serialize(tuple, _options);
+
+		Assert.That(actual, Is.EqualTo(expected));
+	}
 }

--- a/src/Json.More/Json.More.csproj
+++ b/src/Json.More/Json.More.csproj
@@ -14,8 +14,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>Json.More.Net</PackageId>
-    <Version>2.1.1</Version>
-    <FileVersion>2.1.1</FileVersion>
+    <Version>2.1.2</Version>
+    <FileVersion>2.1.2</FileVersion>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>Provides extended functionality for the System.Text.Json namespace.</Description>

--- a/src/Json.More/JsonArrayTupleConverter.cs
+++ b/src/Json.More/JsonArrayTupleConverter.cs
@@ -20,6 +20,11 @@ public class JsonArrayTupleConverter : JsonConverterFactory
 	/// <see langword="true" /> if the instance can convert the specified object type; otherwise, <see langword="false" />.</returns>
 	public override bool CanConvert(Type typeToConvert)
 	{
+		if (typeToConvert.IsArray)
+		{
+			return false;
+		}
+		
 		return typeToConvert.FullName?.StartsWith("System.ValueTuple`") ?? false;
 	}
 

--- a/src/Json.More/JsonArrayTupleConverter.cs
+++ b/src/Json.More/JsonArrayTupleConverter.cs
@@ -20,8 +20,8 @@ public class JsonArrayTupleConverter : JsonConverterFactory
 	/// <see langword="true" /> if the instance can convert the specified object type; otherwise, <see langword="false" />.</returns>
 	public override bool CanConvert(Type typeToConvert)
 	{
-		return !typeToConvert.IsArray
-		       && (typeToConvert.FullName?.StartsWith("System.ValueTuple`") ?? false);
+		return !typeToConvert.IsArray &&
+		       (typeToConvert.FullName?.StartsWith("System.ValueTuple`") ?? false);
 	}
 
 	/// <summary>Creates a converter for a specified type.</summary>

--- a/src/Json.More/JsonArrayTupleConverter.cs
+++ b/src/Json.More/JsonArrayTupleConverter.cs
@@ -20,12 +20,8 @@ public class JsonArrayTupleConverter : JsonConverterFactory
 	/// <see langword="true" /> if the instance can convert the specified object type; otherwise, <see langword="false" />.</returns>
 	public override bool CanConvert(Type typeToConvert)
 	{
-		if (typeToConvert.IsArray)
-		{
-			return false;
-		}
-		
-		return typeToConvert.FullName?.StartsWith("System.ValueTuple`") ?? false;
+		return !typeToConvert.IsArray
+		       && (typeToConvert.FullName?.StartsWith("System.ValueTuple`") ?? false);
 	}
 
 	/// <summary>Creates a converter for a specified type.</summary>

--- a/tools/ApiDocsGenerator/release-notes/rn-json-more.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-more.md
@@ -6,7 +6,7 @@ order: "09.13"
 ---
 # [2.1.2](https://github.com/json-everything/json-everything/pull/888) {#release-more-2.1.2}
 
-[#885](https://github.com/json-everything/json-everything/issues/885) - Fixes an issue in`JsonArrayTupleConverter` 
+[#885](https://github.com/json-everything/json-everything/issues/885) - Fixes an issue in `JsonArrayTupleConverter`.  Thanks to [@MatthewSmit](https://github.com/MatthewSmit) for identifying and providing the fix.
 when serializing/deserializing arrays of tuples.
 
 # [2.1.1](https://github.com/json-everything/json-everything/pull/857) {#release-more-2.1.1}

--- a/tools/ApiDocsGenerator/release-notes/rn-json-more.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-more.md
@@ -4,6 +4,11 @@ title: Json.More.Net
 icon: fas fa-tag
 order: "09.13"
 ---
+# [2.1.2](https://github.com/json-everything/json-everything/pull/888) {#release-more-2.1.2}
+
+[#885](https://github.com/json-everything/json-everything/issues/885) - Fixes an issue in`JsonArrayTupleConverter` 
+when serializing/deserializing arrays of tuples.
+
 # [2.1.1](https://github.com/json-everything/json-everything/pull/857) {#release-more-2.1.1}
 
 [#856](https://github.com/json-everything/json-everything/issues/856) - `EnumStringConverter` fails on Enum serialization when multiple members have same value


### PR DESCRIPTION
### Description
<!--
Please add a short description of the changes.  Be sure to include:
  - whether this affects the public API surface
  - whether the changes cause breaks in either developer experience or behavior
-->
JsonArrayTupleConverter was attempting to serialise/deserialise arrays of tuples, causing a crash. Now it will no longer consider arrays of tuples as a valid type to serialise, so the following code will now serialise/deserialise correctly.
```c#
var result = JsonSerializer.Deserialize<(int, bool)[]>(
    "[[1,true],[2,false]]",
    new JsonSerializerOptions()
    {
        Converters =
        {
            new JsonArrayTupleConverter(),
        }
    });
``` 

### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
Resolves https://github.com/json-everything/json-everything/issues/885

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
