### PR TITLE
Fix schema generation for property override with 'new' keyword  #897

### DIFF
--- a/src/JsonSchema.Generation.Tests/PropertyOverridesTests.cs
+++ b/src/JsonSchema.Generation.Tests/PropertyOverridesTests.cs
@@ -1,0 +1,28 @@
+﻿using System.Linq;
+using NUnit.Framework;
+
+namespace Json.Schema.Generation.Tests;
+
+internal class PropertyOverridesTests
+{
+	[Test]
+	public void TypeWithPropertyOverride_GeneratesCorrectly()
+	{
+		var schema = new JsonSchemaBuilder().FromType<DerivedClassWithProperty>().Build();
+
+		Assert.That(schema, Is.Not.Null, "Schema should not be null.");
+		Assert.That(schema.GetProperties(), Is.Not.Null, "Schema should have properties.");
+		Assert.That(schema.GetProperties().ContainsKey("MyProperty"), Is.True, "Schema should contain MyProperty.");
+		Assert.That((schema.GetProperties()["MyProperty"].Keywords.First() as TypeKeyword).Type == (SchemaValueType.String | SchemaValueType.Null));
+	}
+}
+
+public class BaseClassWithProperty
+{
+	public int MyProperty { get; set; }
+}
+
+public class DerivedClassWithProperty : BaseClassWithProperty
+{
+	public new string? MyProperty { get; set; }
+}

--- a/src/JsonSchema.Generation/JsonSchema.Generation.csproj
+++ b/src/JsonSchema.Generation/JsonSchema.Generation.csproj
@@ -15,8 +15,8 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>5.0.2</Version>
-    <FileVersion>5.0.2</FileVersion>
+    <Version>5.0.3</Version>
+    <FileVersion>5.0.3</FileVersion>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>Extends JsonSchema.Net to provide schema generation functionality</Description>

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema-generation.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema-generation.md
@@ -4,6 +4,11 @@ title: JsonSchema.Net.Generation
 icon: fas fa-tag
 order: "09.05"
 ---
+
+# [5.0.3](https://github.com/json-everything/json-everything/pull/897) {#release-schemagen-5.0.3}
+
+Fixed schema generation for types with property overrides using 'new' keyword
+
 # [5.0.2](https://github.com/json-everything/json-everything/pull/887) {#release-schemagen-5.0.2}
 
 Rerelease of 5.0.1 with fixed package dependencies.  Thanks to [@arturcic](https://github.com/arturcic) for reporting.


### PR DESCRIPTION
### Description
This fixes the issue #897 , where a type with a property override using 'new' keyword would throw an exception when trying to generate the json schema.

Resolves #897

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
