### PR TITLE
JsonPath and JsonE equivalency to JsonNode when dealing with CLR types that JsonNode equates to "String kind"

### DIFF
--- a/src/Json.More/JsonNodeExtensions.cs
+++ b/src/Json.More/JsonNodeExtensions.cs
@@ -223,7 +223,9 @@ public static class JsonNodeExtensions
 		if (value.TryGetValue(out string? s)) return s;
 		if (value.TryGetValue(out char c)) return c.ToString();
 
-		return null;
+		return value.GetValueKind() == JsonValueKind.String
+			? value.ToJsonString()[1..^1] //strip JSON literal double quotes
+			: null;
 	}
 
 	/// <summary>

--- a/src/JsonE/Expressions/Operators/GreaterThanOperator.cs
+++ b/src/JsonE/Expressions/Operators/GreaterThanOperator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Json.More;
 
@@ -14,9 +15,9 @@ internal class GreaterThanOperator : IBinaryOperator
 			right is not JsonValue rValue)
 			throw new InterpreterException("infix: > expects numbers/strings > numbers/strings");
 
-		if (lValue.TryGetValue(out string? leftString) &&
-			rValue.TryGetValue(out string? rightString))
-			return string.Compare(leftString, rightString, StringComparison.Ordinal) > 0;
+		if (lValue.GetValueKind() == JsonValueKind.String &&
+		    rValue.GetValueKind() == JsonValueKind.String)
+			return string.Compare(lValue.GetString(), rValue.GetString(), StringComparison.Ordinal) > 0;
 
 		var lNumber = lValue.GetNumber() ?? throw new InterpreterException("infix: > expects numbers/strings > numbers/strings");
 		var rNumber = rValue.GetNumber() ?? throw new InterpreterException("infix: > expects numbers/strings > numbers/strings");

--- a/src/JsonE/Expressions/Operators/GreaterThanOrEqualToOperator.cs
+++ b/src/JsonE/Expressions/Operators/GreaterThanOrEqualToOperator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Json.More;
 
@@ -14,9 +15,9 @@ internal class GreaterThanOrEqualToOperator : IBinaryOperator
 			right is not JsonValue rValue)
 			throw new InterpreterException("infix: >= expects numbers/strings >= numbers/strings");
 
-		if (lValue.TryGetValue(out string? leftString) &&
-			rValue.TryGetValue(out string? rightString))
-			return string.Compare(leftString, rightString, StringComparison.Ordinal) >= 0;
+		if (lValue.GetValueKind() == JsonValueKind.String &&
+		    rValue.GetValueKind() == JsonValueKind.String)
+			return string.Compare(lValue.GetString(), rValue.GetString(), StringComparison.Ordinal) >= 0;
 
 		var lNumber = lValue.GetNumber() ?? throw new InterpreterException("infix: >= expects numbers/strings >= numbers/strings");
 		var rNumber = rValue.GetNumber() ?? throw new InterpreterException("infix: >= expects numbers/strings >= numbers/strings");

--- a/src/JsonE/Expressions/Operators/LessThanOperator.cs
+++ b/src/JsonE/Expressions/Operators/LessThanOperator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Json.More;
 
@@ -14,9 +15,9 @@ internal class LessThanOperator : IBinaryOperator
 			right is not JsonValue rValue)
 			throw new InterpreterException("infix: < expects numbers/strings < numbers/strings");
 
-		if (lValue.TryGetValue(out string? leftString) &&
-			rValue.TryGetValue(out string? rightString))
-			return string.Compare(leftString, rightString, StringComparison.Ordinal) < 0;
+		if (lValue.GetValueKind() == JsonValueKind.String &&
+		    rValue.GetValueKind() == JsonValueKind.String)
+			return string.Compare(lValue.GetString(), rValue.GetString(), StringComparison.Ordinal) < 0;
 
 		var lNumber = lValue.GetNumber() ?? throw new InterpreterException("infix: < expects numbers/strings < numbers/strings");
 		var rNumber = rValue.GetNumber() ?? throw new InterpreterException("infix: < expects numbers/strings < numbers/strings");

--- a/src/JsonE/Expressions/Operators/LessThanOrEqualToOperator.cs
+++ b/src/JsonE/Expressions/Operators/LessThanOrEqualToOperator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Json.More;
 
@@ -14,9 +15,9 @@ internal class LessThanOrEqualToOperator : IBinaryOperator
 			right is not JsonValue rValue)
 			throw new InterpreterException("infix: <= expects numbers/strings <= numbers/strings");
 
-		if (lValue.TryGetValue(out string? leftString) &&
-			rValue.TryGetValue(out string? rightString))
-			return string.Compare(leftString, rightString, StringComparison.Ordinal) <= 0;
+		if (lValue.GetValueKind() == JsonValueKind.String &&
+		    rValue.GetValueKind() == JsonValueKind.String)
+			return string.Compare(lValue.GetString(), rValue.GetString(), StringComparison.Ordinal) <= 0;
 
 		var lNumber = lValue.GetNumber() ?? throw new InterpreterException("infix: <= expects numbers/strings <= numbers/strings");
 		var rNumber = rValue.GetNumber() ?? throw new InterpreterException("infix: <= expects numbers/strings <= numbers/strings");

--- a/src/JsonPath/Expressions/GreaterThanOperator.cs
+++ b/src/JsonPath/Expressions/GreaterThanOperator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Json.More;
 
@@ -21,9 +22,9 @@ internal class GreaterThanOperator : IBinaryComparativeOperator
 		    rNode is not JsonValue rValue)
 			return false;
 
-		if (lValue.TryGetValue(out string? leftString) &&
-		    rValue.TryGetValue(out string? rightString))
-			return string.Compare(leftString, rightString, StringComparison.Ordinal) > 0;
+		if (lValue.GetValueKind() == JsonValueKind.String &&
+			rValue.GetValueKind() == JsonValueKind.String)
+			return string.Compare(lValue.GetString(), rValue.GetString(), StringComparison.Ordinal) > 0;
 
 		return lValue.GetNumber() > rValue.GetNumber();
 	}

--- a/src/JsonPath/Expressions/GreaterThanOrEqualToOperator.cs
+++ b/src/JsonPath/Expressions/GreaterThanOrEqualToOperator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Json.More;
 
@@ -23,9 +24,9 @@ internal class GreaterThanOrEqualToOperator : IBinaryComparativeOperator
 		    rNode is not JsonValue rValue)
 			return false;
 
-		if (lValue.TryGetValue(out string? leftString) &&
-		    rValue.TryGetValue(out string? rightString))
-			return string.Compare(leftString, rightString, StringComparison.Ordinal) >= 0;
+		if (lValue.GetValueKind() == JsonValueKind.String &&
+		    rValue.GetValueKind() == JsonValueKind.String)
+			return string.Compare(lValue.GetString(), rValue.GetString(), StringComparison.Ordinal) >= 0;
 
 		return lValue.GetNumber() >= rValue.GetNumber();
 	}

--- a/src/JsonPath/Expressions/LessThanOperator.cs
+++ b/src/JsonPath/Expressions/LessThanOperator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Json.More;
 
@@ -21,9 +22,9 @@ internal class LessThanOperator : IBinaryComparativeOperator
 		    rNode is not JsonValue rValue)
 			return false;
 
-		if (lValue.TryGetValue(out string? leftString) &&
-		    rValue.TryGetValue(out string? rightString))
-			return string.Compare(leftString, rightString, StringComparison.Ordinal) < 0;
+		if (lValue.GetValueKind() == JsonValueKind.String &&
+		    rValue.GetValueKind() == JsonValueKind.String)
+			return string.Compare(lValue.GetString(), rValue.GetString(), StringComparison.Ordinal) < 0;
 
 		return lValue.GetNumber() < rValue.GetNumber();
 	}

--- a/src/JsonPath/Expressions/LessThanOrEqualToOperator.cs
+++ b/src/JsonPath/Expressions/LessThanOrEqualToOperator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Json.More;
 
@@ -23,9 +24,9 @@ internal class LessThanOrEqualToOperator : IBinaryComparativeOperator
 		    rNode is not JsonValue rValue)
 			return false;
 
-		if (lValue.TryGetValue(out string? leftString) &&
-		    rValue.TryGetValue(out string? rightString))
-			return string.Compare(leftString, rightString, StringComparison.Ordinal) <= 0;
+		if (lValue.GetValueKind() == JsonValueKind.String &&
+		    rValue.GetValueKind() == JsonValueKind.String)
+			return string.Compare(lValue.GetString(), rValue.GetString(), StringComparison.Ordinal) <= 0;
 
 		return lValue.GetNumber() <= rValue.GetNumber();
 	}


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

<!--
Please add a short description of the changes.  Be sure to include:
  - whether this affects the public API surface
  - whether the changes cause breaks in either developer experience or behavior
-->

Implements a minimal change to JsonPath and JsonE to allow equivalency in "String kind" handling to that implemented in JsonNode.
Public interface is not modified however the behaviours of JsonPath and JsonE is changed when evaluating a JsonNode DOM that contains "String kind" equivalent CLR types.


### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
Resolves #900     <!-- Use if these changes completely resolve the issue -->


### Checks

- [X] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
