### PR TITLE
Update LessThanRule.cs

### DIFF
--- a/src/JsonLogic/Rules/LessThanRule.cs
+++ b/src/JsonLogic/Rules/LessThanRule.cs
@@ -130,7 +130,7 @@ public class LessThanRule : Rule, IRule
 		{
 			if (a != null && a.TryGetValue(out stringA) &&
 			    b != null && b.TryGetValue(out stringB))
-				return string.Compare(stringA, stringB, StringComparison.Ordinal) < 0;
+				return string.Compare(stringA, stringB, StringComparison.Ordinal) <0;
 
 			var numberA = a.Numberify();
 			var numberB = b.Numberify();

--- a/src/JsonLogic/Rules/LessThanRule.cs
+++ b/src/JsonLogic/Rules/LessThanRule.cs
@@ -130,7 +130,7 @@ public class LessThanRule : Rule, IRule
 		{
 			if (a != null && a.TryGetValue(out stringA) &&
 			    b != null && b.TryGetValue(out stringB))
-				return string.Compare(stringA, stringB, StringComparison.Ordinal) <0;
+				return string.Compare(stringA, stringB, StringComparison.Ordinal) < 0;
 
 			var numberA = a.Numberify();
 			var numberB = b.Numberify();

--- a/src/JsonLogic/Rules/LessThanRule.cs
+++ b/src/JsonLogic/Rules/LessThanRule.cs
@@ -130,7 +130,7 @@ public class LessThanRule : Rule, IRule
 		{
 			if (a != null && a.TryGetValue(out stringA) &&
 			    b != null && b.TryGetValue(out stringB))
-				return string.Compare(stringA, stringB, StringComparison.Ordinal) <= 0;
+				return string.Compare(stringA, stringB, StringComparison.Ordinal) < 0;
 
 			var numberA = a.Numberify();
 			var numberB = b.Numberify();


### PR DESCRIPTION
Fx the bug/typo with comparing for LessThenRule with two parameters

### Description

LessThenRule
JsonNode? IRule.Apply(JsonNode? args, EvaluationContext context) method
comparing two equals strings returns true, but should be false

### Links

https://github.com/json-everything/json-everything/issues/916

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
