### PR TITLE
schema generation updates

### DIFF
--- a/src/JsonSchema.Generation.Tests/ClientTests.cs
+++ b/src/JsonSchema.Generation.Tests/ClientTests.cs
@@ -566,11 +566,22 @@ public class ClientTests
 	[Test]
 	public void Issue915_ExternalRef()
 	{
+		var expected = new JsonSchemaBuilder()
+			.Type(SchemaValueType.Object)
+			.Properties(
+				("Bar", new JsonSchemaBuilder()
+					.Ref("https://some.domain.com/someType")
+				),
+				("Baz", new JsonSchemaBuilder()
+					.Ref("https://some.domain.com/someType")
+				)
+			);
+
 		var genConfig = new SchemaGeneratorConfiguration(); 
 		genConfig.ExternalReferences.Add(typeof(Issue915_SomeType), new Uri("https://some.domain.com/someType"));
 
 		var schema = new JsonSchemaBuilder().FromType<Issue915_RootType>(genConfig);
 
-		AssertEqual(true, schema);
+		AssertEqual(expected, schema);
 	}
 }

--- a/src/JsonSchema.Generation.Tests/TestEnvironment.cs
+++ b/src/JsonSchema.Generation.Tests/TestEnvironment.cs
@@ -1,6 +1,8 @@
-﻿using System.Text.Encodings.Web;
+﻿using System.Drawing;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Json.Schema.Generation.Tests.Serialization;
 
 namespace Json.Schema.Generation.Tests;
 
@@ -15,6 +17,10 @@ internal static class TestEnvironment
 		};
 }
 
+[JsonSerializable(typeof(Point))]
 [JsonSerializable(typeof(JsonSchema))]
+[JsonSerializable(typeof(EvaluationResults))]
 [JsonSerializable(typeof(PropertiesKeyword))]
+[JsonSerializable(typeof(DeserializationTests.Foo))]
+[JsonSerializable(typeof(DeserializationTests.FooWithSchema))]
 public partial class TestSerializerContext : JsonSerializerContext;

--- a/src/JsonSchema.Generation/Intents/RefIntent.cs
+++ b/src/JsonSchema.Generation/Intents/RefIntent.cs
@@ -13,6 +13,7 @@ public class RefIntent : ISchemaKeywordIntent
 	public Uri Reference { get; set; }
 
 	internal MemberGenerationContext? Context { get; }
+	internal bool IsExternalRef { get; set; }
 
 	/// <summary>
 	/// Creates a new <see cref="RefIntent"/> instance.

--- a/src/JsonSchema.Generation/MemberGenerationContext.cs
+++ b/src/JsonSchema.Generation/MemberGenerationContext.cs
@@ -65,7 +65,7 @@ public class MemberGenerationContext : SchemaGenerationContextBase
 		List<ISchemaKeywordIntent> baseIntents;
 		if (BasedOn.IsRoot)
 			baseIntents = [new RefIntent(this, new Uri("#", UriKind.Relative))];
-		else if (nullable || !Type.CanBeReferenced())
+		else if (nullable || !Type.CanBeReferenced() || BasedOn.IsSimpleRef())
 			baseIntents = BasedOn.Intents;
 		else
 		{

--- a/src/JsonSchema.Generation/SchemaGenerationContextCache.cs
+++ b/src/JsonSchema.Generation/SchemaGenerationContextCache.cs
@@ -37,10 +37,11 @@ public static class SchemaGenerationContextCache
 	{
 		var baseContext = Get(type, true);
 		var toReintegrate = Cache
-			.Where(x => (x.Value.References.Count == 1 &&
-			            x.Key != type &&
-			            x.Key.CanBeReferenced()) ||
-			            x.Value.Intents is [RefIntent])
+			.Where(x => ((x.Value.References.Count == 1 &&
+			              x.Key != type &&
+			              x.Key.CanBeReferenced()) ||
+			             x.Value.Intents is [RefIntent]) &&
+			            !x.Value.IsSimpleRef())
 			.Select(x => x.Value)
 			.ToList();
 

--- a/src/JsonSchema.Generation/Serialization/GenerateJsonSchemaAttribute.cs
+++ b/src/JsonSchema.Generation/Serialization/GenerateJsonSchemaAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Json.Schema.Generation.Serialization;
+
+/// <summary>
+/// Apply to a type to generate a schema for validation during deserialization
+/// by <see cref="GenerativeValidatingJsonConverter"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct)]
+public class GenerateJsonSchemaAttribute : Attribute;

--- a/src/JsonSchema.Generation/Serialization/GenerativeValidatingJsonConverter.cs
+++ b/src/JsonSchema.Generation/Serialization/GenerativeValidatingJsonConverter.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Json.Schema.Serialization;
+
+namespace Json.Schema.Generation.Serialization;
+
+/// <summary>
+/// Extends <see cref="ValidatingJsonConverter"/> to also allow for
+/// schema generation using <see cref="GenerateJsonSchemaAttribute"/>.
+/// </summary>
+public class GenerativeValidatingJsonConverter : ValidatingJsonConverter
+{
+	/// <summary>
+	/// Provides options for the generator.
+	/// </summary>
+	public SchemaGeneratorConfiguration GeneratorConfiguration { get; } = new();
+
+	/// <summary>When overridden in a derived class, determines whether the converter instance can convert the specified object type.</summary>
+	/// <param name="typeToConvert">The type of the object to check whether it can be converted by this converter instance.</param>
+	/// <returns>
+	/// <see langword="true" /> if the instance can convert the specified object type; otherwise, <see langword="false" />.</returns>
+	public override bool CanConvert(Type typeToConvert)
+	{
+		var canConvert = typeToConvert.GetCustomAttributes(typeof(GenerateJsonSchemaAttribute)).SingleOrDefault() != null;
+
+		return canConvert || base.CanConvert(typeToConvert);
+	}
+
+	/// <summary>
+	/// Gets the schema for a type.
+	/// </summary>
+	protected override JsonSchema GetSchema(Type type)
+	{
+		var generateAttribute = type.GetCustomAttributes(typeof(GenerateJsonSchemaAttribute)).SingleOrDefault();
+		if (generateAttribute is not null)
+		{
+			var schema = new JsonSchemaBuilder().FromType(type, GeneratorConfiguration);
+			return schema;
+		}
+
+		return base.GetSchema(type);
+	}
+}

--- a/src/JsonSchema.Generation/TypeGenerationContext.cs
+++ b/src/JsonSchema.Generation/TypeGenerationContext.cs
@@ -46,7 +46,7 @@ public class TypeGenerationContext : SchemaGenerationContextBase
 		var configuration = SchemaGeneratorConfiguration.Current;
 
 		if (configuration.ExternalReferences.TryGetValue(Type, out var uri))
-			Intents.Add(new RefIntent(uri));
+			Intents.Add(new RefIntent(uri) { IsExternalRef = true });
 		else
 		{
 			var runGenerator = true;
@@ -75,6 +75,8 @@ public class TypeGenerationContext : SchemaGenerationContextBase
 			refiner.Run(this);
 		}
 	}
+
+	internal bool IsSimpleRef() => Intents is [RefIntent { IsExternalRef: true }];
 
 	[RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
 	private static IComparer<MemberInfo> GetComparer(Type type)

--- a/src/JsonSchema.Test.Api/Program.cs
+++ b/src/JsonSchema.Test.Api/Program.cs
@@ -16,8 +16,11 @@ builder.Services.ConfigureHttpJsonOptions(opt =>
 {
 	opt.SerializerOptions.Converters.Add(new ValidatingJsonConverter
 	{
-		RequireFormatValidation = true,
-		OutputFormat = OutputFormat.List
+		Options =
+		{
+			RequireFormatValidation = true,
+			OutputFormat = OutputFormat.List
+		}
 	});
 });
 var app = builder.Build();

--- a/src/JsonSchema.Tests/GithubTests.cs
+++ b/src/JsonSchema.Tests/GithubTests.cs
@@ -1187,7 +1187,7 @@ public class GithubTests
 	private static void Run791<T>()
 	{
 		var jsonText = @"{ ""Foo"": ""foo"",  ""Bar"": -42 }";
-		var converter = new ValidatingJsonConverter { OutputFormat = OutputFormat.List };
+		var converter = new ValidatingJsonConverter { Options = { OutputFormat = OutputFormat.List } };
 		var options = new JsonSerializerOptions(TestEnvironment.TestOutputSerializerOptions) { Converters = { converter } };
 		var ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<T>(jsonText, options));
 		var result = ex.Data["validation"] as EvaluationResults;

--- a/src/JsonSchema/JsonSchema.csproj
+++ b/src/JsonSchema/JsonSchema.csproj
@@ -17,7 +17,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
 
     <PackageId>JsonSchema.Net</PackageId>
-    <JsonSchemaNetVersion>7.3.4</JsonSchemaNetVersion>
+    <JsonSchemaNetVersion>7.4.0</JsonSchemaNetVersion>
     <AssemblyVersion>7.0.0.0</AssemblyVersion>
     <FileVersion>$(JsonSchemaNetVersion)</FileVersion>
     <Version>$(JsonSchemaNetVersion)</Version>


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

<!--
Please add a short description of the changes.  Be sure to include:
  - whether this affects the public API surface
  - whether the changes cause breaks in either developer experience or behavior
-->

- **JsonSchema.Net**
  - Adds full options to `ValidatingJsonConverter` (obsoletes explicit option properties)
  - Sets up `ValidationJsonConverter` to be inherited in JsonSchema.Net.Generation
- **JsonSchema.Net.Generation**
  - Adds `GenerativeValidatingJsonConverter`
  - Adds `GenerateJsonSchema`
  - Fixes bug where multiple external `$ref`s would generate with a `$defs` URI.

### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
Resolves #915     <!-- Use if these changes completely resolve the issue -->

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
