### PR TITLE
Fix for operators And and Or

### DIFF
--- a/src/JsonLogic.Tests/Files/more-tests.json
+++ b/src/JsonLogic.Tests/Files/more-tests.json
@@ -130,5 +130,11 @@
 			{"+":[{"var":"current"}, 5]},
 			10
 		]}, {}, 10 ],
+  [ {"and": [ { "missing": "var1" }, [{ "cat": [ { "var": "var2" }, "[", { "var": "idx"}, "] invalid" ]}]] },
+    { "var2": "object", "idx": 0},
+    [ "object[0] invalid"]],
+  [ {"or": [ { "missing": "var2" }, [{ "cat": [ { "var": "var2" }, "[", { "var": "idx"}, "] valid" ]}]] },
+    { "var2": "object", "idx": 0},
+    [ "object[0] valid"]],
 	"EOF"
 ]

--- a/src/JsonLogic/JsonLogic.csproj
+++ b/src/JsonLogic/JsonLogic.csproj
@@ -15,8 +15,8 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>5.4.1</Version>
-    <FileVersion>5.4.1</FileVersion>
+    <Version>5.4.2</Version>
+    <FileVersion>5.4.2</FileVersion>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>JsonLogic built on the System.Text.Json namespace</Description>

--- a/src/JsonLogic/Rules/AndRule.cs
+++ b/src/JsonLogic/Rules/AndRule.cs
@@ -77,7 +77,7 @@ public class AndRule : Rule, IRule
 		JsonNode? result = null;
 		foreach (var item in array)
 		{
-			result = item is JsonObject innerRule ? JsonLogic.Apply(innerRule, context) : item;
+			result = JsonLogic.Apply(item, context);
 			if (!result.IsTruthy()) break;
 		}
 

--- a/src/JsonLogic/Rules/OrRule.cs
+++ b/src/JsonLogic/Rules/OrRule.cs
@@ -77,7 +77,7 @@ public class OrRule : Rule, IRule
 		JsonNode? result = false;
 		foreach (var item in array)
 		{
-			result = item is JsonObject innerRule ? JsonLogic.Apply(innerRule, context) : item;
+			result = JsonLogic.Apply(item, context);
 			if (result.IsTruthy()) break;
 		}
 

--- a/tools/ApiDocsGenerator/release-notes/rn-json-logic.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-logic.md
@@ -4,6 +4,10 @@ title: JsonLogic
 icon: fas fa-tag
 order: "09.11"
 ---
+# [5.4.2](https://github.com/json-everything/json-everything/pull/923) {#release-logic-5.4.2}
+
+[#922](https://github.com/gregsdennis/json-everything/issues/922) - Operators `and` and `or` have lost feature to return the last argument with applied rules in IRule implementation.  Thanks to [@alexkharuk](https://github.com/alexkharuk) for finding and fixing this issue.
+
 # [5.4.1](https://github.com/gregsdennis/json-everything/pull/919) {#release-logic-5.4.1}
 
 [#916](https://github.com/gregsdennis/json-everything/issues/916) - `<` not working correctly when comparing two strings.  Thanks to [@alexkharuk](https://github.com/alexkharuk) for finding and fixing this issue.


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

Operators And and Or have lost feature to return the last argument with applied rules in IRule implementation

### Links

Resolves https://github.com/json-everything/json-everything/issues/922

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
