### PR TITLE
Fix for dynamically constructed paths in VariableRule

### DIFF
--- a/src/JsonLogic.Tests/Files/more-tests.json
+++ b/src/JsonLogic.Tests/Files/more-tests.json
@@ -130,11 +130,12 @@
 			{"+":[{"var":"current"}, 5]},
 			10
 		]}, {}, 10 ],
-  [ {"and": [ { "missing": "var1" }, [{ "cat": [ { "var": "var2" }, "[", { "var": "idx"}, "] invalid" ]}]] },
-    { "var2": "object", "idx": 0},
-    [ "object[0] invalid"]],
-  [ {"or": [ { "missing": "var2" }, [{ "cat": [ { "var": "var2" }, "[", { "var": "idx"}, "] valid" ]}]] },
-    { "var2": "object", "idx": 0},
-    [ "object[0] valid"]],
+	[ {"and": [ { "missing": "var1" }, [{ "cat": [ { "var": "var2" }, "[", { "var": "idx"}, "] invalid" ]}]] },
+		{ "var2": "object", "idx": 0},
+		[ "object[0] invalid"]],
+	[ {"or": [ { "missing": "var2" }, [{ "cat": [ { "var": "var2" }, "[", { "var": "idx"}, "] valid" ]}]] },
+		{ "var2": "object", "idx": 0},
+		[ "object[0] valid"]],
+	[ {"var": {"cat": ["fruit.", {"var": "type"}]}}, {"fruit": {"apple": "red"}, "type": "apple"}, "red"],
 	"EOF"
 ]

--- a/src/JsonLogic/Rules/VariableRule.cs
+++ b/src/JsonLogic/Rules/VariableRule.cs
@@ -69,8 +69,6 @@ public class VariableRule : Rule, IRule
 			if (array.Count > 1)
 				defaultValue = array[1];
 		}
-		else
-			pathValue = args.Stringify();
 
 		var path = JsonLogic.Apply(pathValue, context).Stringify();
 		if (path == string.Empty) return context.CurrentValue;


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description
Fix VariableRule for concatenated variable paths in IRule implementation

<!--
Please add a short description of the changes.  Be sure to include:
  - whether this affects the public API surface
  - whether the changes cause breaks in either developer experience or behavior
-->

### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
Resolves https://github.com/json-everything/json-everything/issues/927


### Checks

- [ ] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
